### PR TITLE
detect changes in jam track properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 
 config.ini
 known_songs.json
+known_tracks.json

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Festival Info is a Discord bot that tracks and reports new songs in Fortnite Fes
 
 ## Features
 
-- **Real-Time Song Tracking:** The bot checks Fortnite Festival every 15 minutes and reports new songs to specified Discord channels.
+- **Real-Time Song Tracking:** The bot checks Fortnite Festival every 7 minutes and reports new songs to specified Discord channels.
 - **Daily Tracks Report:** The bot can generate a list of daily tracks and display them in Discord.
 - **Search Functionality:** The bot allows users to search for songs by title or artist.
 


### PR DESCRIPTION
- changes the track detection speed from *15 minutes to *7 minutes
- fixes some null usernames on lbs (yes)

# 
- saves a file with the spark-tracks contents in it
- if the api gives different results than the saved jam track data, they are compared and the differences shown on the channel ids
- supports diffs too

https://cdn.discordapp.com/attachments/1234911518626287657/1281303961667637261/20240905-1718-17.7779691.mp4?ex=66db3acd&is=66d9e94d&hm=c014c47219f8da378d76e8562988eda723499e22d9bfcfbfe2d3c5ee380e797e& (sample file used, in reality the api is fetched)