### PR TITLE
channel & dm subscribing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-
+channels.json
 config.ini
 known_songs.json
 known_tracks.json
@@ -9,3 +9,4 @@ prefixes.json
 json
 midi_files
 **/__pycache__
+backups/

--- a/README.md
+++ b/README.md
@@ -45,8 +45,6 @@ Festival Info is a Discord bot that tracks and reports new songs in Fortnite Fes
     [discord]
     # your bot token, duplicate this file to config.ini and add it there
     token = YOUR_DISCORD_BOT_TOKEN_HERE
-    # list of channel ids the bot sends jam track updates to
-    channel_ids = 123456789012345678, 234567890123456789
     # the command prefix the bot will use
     prefix = !
     # the channel ids the bot is allowed to be triggered by a command in
@@ -71,8 +69,6 @@ Festival Info is a Discord bot that tracks and reports new songs in Fortnite Fes
     ```
 
    - Replace `YOUR_DISCORD_BOT_TOKEN` with your actual Discord bot token.
-   - Replace the `channel_ids` with the IDs of the channels where you want the bot to report new songs.
-   - Replace the `prefix` with the specific prefix the bot will use.
    - Follow the comments to customize the configuration more
 
 4. Run the bot:

--- a/bot/config.py
+++ b/bot/config.py
@@ -1,0 +1,113 @@
+from datetime import datetime
+import enum
+import json
+import os
+
+from bot import constants
+
+class JamTrackEvent(enum.Enum):
+    Modified = 'modified'
+    Added = 'added'
+    Removed = 'removed'
+
+    def get_all_events():
+        return ['added', 'modified', 'removed']
+
+class SubscriptionChannel():
+    def __init__(self) -> None:
+        self.id : int = None
+        self.events : list[str] = None
+        self.roles : list[int] = None # Roles to ping when an event occurs
+        self.type : str = 'channel'
+
+class SubscriptionUser():
+    def __init__(self) -> None:
+        self.id : int = None
+        self.events : list[str] = None
+        self.roles : list[int] = None # Roles to ping when an event occurs
+        self.type : str = 'user'
+
+class Config:
+    def __init__(self, config_file: str, reload_callback) -> None:
+        self.channels : list[SubscriptionChannel] = []
+        self.users : list[SubscriptionUser] = []
+        self.file = config_file
+        self.callback = reload_callback
+
+        self.load()
+
+    def save_config(self):
+        list_object = {
+            'channels': [],
+            'users': []
+        }
+        for channel in self.channels:
+            if any(user.id == channel.id for user in self.users): # Attempt to remove duplicates
+                continue # PD: I don't know what causes duplication
+            
+            list_object['channels'].append({
+                'id': channel.id,
+                'events': channel.events,
+                'roles': channel.roles,
+                'type': 'channel'
+            })
+
+        for user in self.users:
+            if any(channel.id == user.id for channel in self.channels): # Remove duplicates, too.
+                continue
+
+            list_object['users'].append({
+                'id': user.id,
+                'events': user.events,
+                'roles': [],
+                'type': 'user'
+            })
+
+        # if something fails, attempt to recover
+        previous_file_content = open(self.file, 'r').read()
+
+        try:
+            # the json module likes erasing the entire file first before 
+            # checking if the object is actually serializable
+            open(self.file, 'w').write(json.dumps(list_object, indent=4))
+
+            # Tell the bot to completely reload the config
+            self.callback()
+
+        except Exception as e:
+            open(self.file, 'w').write(previous_file_content)
+            print(f'RECOVERED CONFIG FILE: {e}\nRaising an Exception')
+            raise Exception
+        
+        with open(os.path.join(constants.BACKUP_FOLDER, self.create_backup_name()), 'w') as backup_file:
+            backup_file.write(open(self.file, 'r').read())
+        
+    def create_backup_name(self):
+        return f'backup_channels_{int(datetime.now().timestamp())}.json'
+
+    def load_channels(self, data):
+        self.channels = []
+        for channel in data.get('channels', []):
+            channel_object = SubscriptionChannel()
+            channel_object.id = channel['id']
+            channel_object.events = channel['events']
+            channel_object.roles = channel['roles']
+            self.channels.append(channel_object)
+
+    def load_users(self, data):
+        self.users = []
+        for user in data.get('users', []):
+            user_object = SubscriptionUser()
+            user_object.id = user['id']
+            user_object.events = user['events']
+            user_object.roles = []
+            self.users.append(user_object)
+
+    def load(self):
+        if not os.path.exists(self.file):
+            open(self.file, 'w').write('')
+            self.save_config()
+
+        data = json.load(open(self.file, 'r'))
+        self.load_channels(data)
+        self.load_users(data)

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -19,6 +19,10 @@ TEMP_FOLDER = "out/"
 if not os.path.exists(TEMP_FOLDER):
     os.makedirs(TEMP_FOLDER)
 
+BACKUP_FOLDER = 'backups/'
+if not os.path.exists(BACKUP_FOLDER):
+    os.makedirs(BACKUP_FOLDER)
+
 # Files used to track songs
 SONGS_FILE = 'known_tracks.json'  # File to save known songs
 SHORTNAME_FILE = 'known_songs.json'  # File to save known shortnames

--- a/config_default.ini
+++ b/config_default.ini
@@ -2,10 +2,6 @@
 [discord]
 # your bot token, duplicate this file to config.ini and add it there
 token = YOUR_DISCORD_BOT_TOKEN_HERE
-# list of channel ids the bot sends jam track updates to
-channel_ids = 123456789012345678, 234567890123456789
-# the command prefix the bot will use
-prefix = !
 # the channel ids the bot is allowed to be triggered by a command in
 command_channel_ids = 123456789012345678, 234567890123456789
 # change this to true if you want the bot to be triggered only in the channels above

--- a/festivalinfobot.py
+++ b/festivalinfobot.py
@@ -1,9 +1,12 @@
+import json
 import time
 from discord.ext import commands, tasks
 import discord
+from discord import app_commands
 from configparser import ConfigParser
 
-from bot import constants, embeds
+from bot import config, constants, embeds
+from bot.config import Config
 from bot.history import HistoryHandler, LoopCheckHandler
 from bot.leaderboard import LeaderboardCommandHandler
 from bot.path import PathCommandHandler
@@ -45,12 +48,13 @@ class FestivalInfoBot(commands.Bot):
         config = ConfigParser()
         config.read('config.ini')
 
+        def reload_config():
+           self.config = Config(config_file="channels.json", reload_callback=reload_config) 
+
+        self.config = Config(config_file="channels.json", reload_callback=reload_config)
+
         # Read the Discord bot token and channel IDs from the config file
         DISCORD_TOKEN = config.get('discord', 'token')
-        CHANNEL_IDS = config.get('discord', 'channel_ids', fallback="").split(',')
-
-        # Convert channel IDs to integers and filter out any empty strings
-        self.CHANNEL_IDS = [int(id.strip()) for id in CHANNEL_IDS if id.strip()]
 
         # Bot configuration properties
         self.CHECK_FOR_SONGS_INTERVAL = config.getint('bot', 'check_new_songs_interval', fallback=7)
@@ -63,6 +67,7 @@ class FestivalInfoBot(commands.Bot):
 
         # Set up Discord bot with necessary intents
         intents = discord.Intents.default()
+        intents.members = True
         intents.message_content = True  # Enable message content intent
 
         super().__init__(
@@ -82,11 +87,13 @@ class FestivalInfoBot(commands.Bot):
         self.check_handler = LoopCheckHandler(self)
 
         self.setup_commands()
+        self.setup_subscribe_commands()
 
         self.run(DISCORD_TOKEN)
 
     def setup_commands(self):
         @self.tree.command(name="search", description="Search a song.")
+        @app_commands.describe(query = "A search query: an artist, song name, or shortname.")
         async def search_command(interaction: discord.Interaction, query:str):
             await self.search_handler.handle_interaction(interaction=interaction, query=query)
 
@@ -118,6 +125,11 @@ class FestivalInfoBot(commands.Bot):
             await interaction.response.send_message(embed=embed)
 
         @self.tree.command(name="leaderboard", description="View the leaderboard of a song.")
+        @app_commands.describe(song = "A search query: an artist, song name, or shortname.")
+        @app_commands.describe(instrument = "The instrument to view the leaderboard of.")
+        @app_commands.describe(rank = "A number from 1 to 500 to view a specific entry in the leaderboard.")
+        @app_commands.describe(username = "An Epic Games account's username. Not case-sensitive.")
+        @app_commands.describe(account_id = "An Epic Games account ID.")
         async def leaderboard_command(interaction: discord.Interaction, song:str, instrument:constants.Instruments, rank: discord.app_commands.Range[int, 1, 500] = None, username:str = None, account_id:str = None):
             await self.lb_handler.handle_interaction(
                 interaction,
@@ -129,6 +141,10 @@ class FestivalInfoBot(commands.Bot):
             )
 
         @self.tree.command(name="path", description="Generates an Overdrive path for a song using CHOpt.")
+        @app_commands.describe(song = "A search query: an artist, song name, or shortname.")
+        @app_commands.describe(instrument = "The instrument to view the path of.")
+        @app_commands.describe(squeeze_percent = "Squeeze Percent value")
+        @app_commands.describe(difficulty = "The difficulty to view the path for")
         async def path_command(interaction: discord.Interaction, song:str, instrument:constants.Instruments, squeeze_percent: discord.app_commands.Range[int, 0, 100] = 20, difficulty:constants.Difficulties = constants.Difficulties.Expert):
             if not self.PATHING_ALLOWED or not self.DECRYPTION_ALLOWED:
                 await interaction.response.send_message(content="This command is not enabled in this bot.", ephemeral=True)
@@ -143,6 +159,7 @@ class FestivalInfoBot(commands.Bot):
             )
 
         @self.tree.command(name="history", description="View the history of a Jam Track.")
+        @app_commands.describe(song = "A search query: an artist, song name, or shortname.")
         async def history_command(interaction: discord.Interaction, song:str):
             if not self.CHART_COMPARING_ALLOWED or not self.DECRYPTION_ALLOWED:
                 await interaction.response.send_message(content="This command is not enabled in this bot.", ephemeral=True)
@@ -188,6 +205,7 @@ class FestivalInfoBot(commands.Bot):
             await interaction.channel.send(content="Full history run completed.")
 
         @self.tree.command(name="metahistory", description="View the metadata history of a Jam Track.")
+        @app_commands.describe(song = "A search query: an artist, song name, or shortname.")
         async def metahistory_command(interaction: discord.Interaction, song:str):
             await self.history_handler.handle_metahistory_interaction(interaction=interaction, song=song)
 
@@ -232,6 +250,7 @@ class FestivalInfoBot(commands.Bot):
             await interaction.response.send_message(embed=embed)
 
         @self.tree.command(name="help", description="Show the help message")
+        @app_commands.describe(command = "The command to view help about.")
         async def help_command(interaction: discord.Interaction, command:str = None):
             if command:
                 if self.tree.get_command(command):
@@ -261,5 +280,433 @@ class FestivalInfoBot(commands.Bot):
                     )
 
             await interaction.response.send_message(embed=embed)
+
+    def setup_subscribe_commands(self):
+        # Setup all the subscription commands
+        
+        async def set_channel_subscription(interaction: discord.Interaction, channel: discord.channel.TextChannel, remove: bool = False) -> bool:
+            channel_list = [subscribed_channel for subscribed_channel in self.config.channels if subscribed_channel.id == channel.id]
+            channel_exists = len(channel_list) > 0
+
+            event_names = {
+                'added': "Jam Track Added",
+                'removed': "Jam Track Removed",
+                'modified': "Jam Track Modified"
+            }
+
+            if remove:
+                # User ran /unsubscribe on a channel which isnt subscribed
+                if not channel_exists:
+                    await interaction.response.send_message(f"The channel <#{channel.id}> is not subscribed.")
+                    return False
+                # User ran /unsubscribe
+                else:
+                    try:
+                        self.config.channels.remove(channel_list[0])
+                    except ValueError as e:
+                        await interaction.response.send_message(f"The channel <#{channel.id}> could not be unsubscribed: {e}")
+                        return False
+            else:
+                # User ran /subscribe on a channel which is already subscribed
+                if channel_exists:
+                    channel_events = channel_list[0].events
+                    if len(channel_events) == len(config.JamTrackEvent.get_all_events()):
+                        await interaction.response.send_message(f"The channel <#{channel.id}> is already subscribed to all Jam Track events.")
+                    else:    
+                        await interaction.response.send_message(f"The channel <#{channel.id}> is already subscribed to the events \"{'\", \"'.join([event_names[event] for event in channel_events])}\".")
+                    return False
+                # User ran /subscribe
+                else:
+                    new_channel = config.SubscriptionChannel()
+                    new_channel.id = channel.id
+                    new_channel.roles = []
+                    new_channel.events = config.JamTrackEvent.get_all_events()
+                    self.config.channels.append(new_channel)
+
+            try:
+                self.config.save_config()
+            except Exception as e:
+                await interaction.response.send_message(f"The bot's subscription list could not be updated to " + ("remove" if remove else "include") + f" <#{channel.id}>: {e}\n" + ("Unsubscription" if remove else "Subscription") + " cancelled.")
+                return False
+                    
+            return True
+
+        async def check_permissions(interaction: discord.Interaction, channel: discord.channel.TextChannel) -> bool:
+            # There are so many permissions we have to check for
+
+            # View the channel
+            if not channel.permissions_for(channel.guild.me).view_channel:
+                await interaction.response.send_message(f'I can\'t view that channel! Please make sure I have the "View Channel" permission in that channel.')
+                return False
+            
+            # Send messages in the channel
+            if not channel.permissions_for(channel.guild.me).send_messages:
+                await interaction.response.send_message(f'I can\'t send messages in that channel! Please make sure I have the "Send Messages" permission in <#{channel.id}>.')
+                return False
+            
+            # If news channel, publish messages (Manage Messages permission!!!)
+            if channel.is_news():
+                if not channel.permissions_for(channel.guild.me).manage_messages:
+                    await interaction.response.send_message(f'I can\'t publish messages in that Announcement channel! Please make sure I have the "Manage Messages" permission in <#{channel.id}>.')
+                    return False
+                
+            # Possible, "Embed Links", "Attach Files?"
+
+            return True
+
+        @self.tree.command(name="subscribe", description="Subscribe a channel to Jam Track events")
+        @app_commands.describe(channel = "The channel to send Jam Track events to.")
+        @app_commands.checks.has_permissions(administrator=True)
+        async def subscribe(interaction: discord.Interaction, channel: discord.channel.TextChannel):
+            permission_result = await check_permissions(interaction=interaction, channel=channel)
+            if not permission_result:
+                return
+            
+            subscription_result = await set_channel_subscription(interaction=interaction, channel=channel, remove=False)
+            if not subscription_result:
+                return
+            
+            await interaction.response.send_message(f"The channel <#{channel.id}> has been subscribed to all Jam Track events.")
+
+        @self.tree.command(name="unsubscribe", description="Unsubscribe a channel from Jam Track events")
+        @app_commands.describe(channel = "The channel to stop sending Jam Track events to.")
+        @app_commands.checks.has_permissions(administrator=True)
+        async def unsubscribe(interaction: discord.Interaction, channel: discord.channel.TextChannel):
+            permission_result = await check_permissions(interaction=interaction, channel=channel)
+            if not permission_result:
+                return
+            
+            subscription_result = await set_channel_subscription(interaction=interaction, channel=channel, remove=True)
+            if not subscription_result:
+                return
+            
+            await interaction.response.send_message(f"The channel <#{channel.id}> has been unsubscribed from all Jam Track events.")
+
+        @self.tree.command(name="add_event", description="Add a Jam Track event to a channel")
+        @app_commands.describe(channel = "The channel to add a Jam Track event to")
+        @app_commands.describe(event = "The event to add")
+        @app_commands.checks.has_permissions(administrator=True)
+        async def add_event(interaction: discord.Interaction, channel: discord.channel.TextChannel, event: config.JamTrackEvent):
+            channel_list = [subscribed_channel for subscribed_channel in self.config.channels if subscribed_channel.id == channel.id]
+            channel_exists = len(channel_list) > 0
+            chosen_event = config.JamTrackEvent[str(event).replace('JamTrackEvent.', '')].value
+
+            event_names = {
+                'added': "Jam Track Added",
+                'removed': "Jam Track Removed",
+                'modified': "Jam Track Modified"
+            }
+
+            if not channel_exists:
+                # Only check for permissions if the channel is added
+                permission_result = await check_permissions(interaction=interaction, channel=channel)
+                if not permission_result:
+                    return
+
+                new_channel = config.SubscriptionChannel()
+                new_channel.id = channel.id
+                new_channel.roles = []
+                new_channel.events = [chosen_event]
+                self.config.channels.append(new_channel)
+            else:
+                subscribed_events = self.config.channels[self.config.channels.index(channel_list[0])].events
+                if chosen_event in subscribed_events:
+                    await interaction.response.send_message(f'The channel <#{channel.id}> is already subscribed to the event "{event_names[chosen_event]}".')
+                    return
+                else:
+                    self.config.channels[self.config.channels.index(channel_list[0])].events.append(chosen_event)
+
+            try:
+                self.config.save_config()
+            except Exception as e:
+                await interaction.response.send_message(f"The bot's subscription list could not be updated to add the event \"{event_names[chosen_event]}\" to the channel <#{channel.id}>: {e}\nEvent subscription cancelled.")
+                return
+            
+            await interaction.response.send_message(f'The channel <#{channel.id}> has been subscribed to the event "{event_names[chosen_event]}".')
+
+        @self.tree.command(name="remove_event", description="Remove a Jam Track event from a channel")
+        @app_commands.describe(channel = "The channel to remove a Jam Track event from")
+        @app_commands.describe(event = "The event to remove")
+        @app_commands.checks.has_permissions(administrator=True)
+        async def remove_event(interaction: discord.Interaction, channel: discord.channel.TextChannel, event: config.JamTrackEvent):
+            channel_list = [subscribed_channel for subscribed_channel in self.config.channels if subscribed_channel.id == channel.id]
+            channel_exists = len(channel_list) > 0
+            chosen_event = config.JamTrackEvent[str(event).replace('JamTrackEvent.', '')].value
+
+            event_names = {
+                'added': "Jam Track Added",
+                'removed': "Jam Track Removed",
+                'modified': "Jam Track Modified"
+            }
+
+            if not channel_exists:
+                await interaction.response.send_message(f'The channel <#{channel.id}> is not subscribed to any events.')
+                return
+            else:
+                subscribed_events = self.config.channels[self.config.channels.index(channel_list[0])].events
+
+                if chosen_event in subscribed_events:
+                    try:
+                        self.config.channels[self.config.channels.index(channel_list[0])].events.remove(chosen_event)
+
+                        # Remove the channel from the subscription list if it isnt subscribed to any events
+                        if len(self.config.channels[self.config.channels.index(channel_list[0])].events) < 1:
+                            self.config.channels.remove(channel_list[0])
+                            self.config.save_config()
+                            await interaction.response.send_message(f"The channel <#{channel.id}> has been removed from the subscription list because it is no longer subscribed to any events.")
+                            return
+
+                    except Exception as e:
+                        await interaction.response.send_message(f"The bot's subscription list could not be updated to remove the event \"{event_names[chosen_event]}\" from the channel <#{channel.id}>: {e}\nEvent unsubscription cancelled.")
+                        return
+                else:
+                    await interaction.response.send_message(f'The channel <#{channel.id}> is not subscribed to the event "{event_names[chosen_event]}".')
+                    return
+
+            try:
+                self.config.save_config()
+            except Exception as e:
+                await interaction.response.send_message(f"The bot's subscription list could not be updated to remove the event \"{event_names[chosen_event]}\" from the channel <#{channel.id}>: {e}\nEvent unsubscription cancelled.")
+                return
+            
+            await interaction.response.send_message(f'The channel <#{channel.id}> has been unsubscribed from the event "{event_names[chosen_event]}".')
+
+        @self.tree.command(name="add_role", description="Add a role ping to a channel's subscription messages")
+        @app_commands.describe(channel = "The channel to add a role ping to")
+        @app_commands.describe(role = "The role to add a ping for")
+        @app_commands.checks.has_permissions(administrator=True)
+        async def add_role(interaction: discord.Interaction, channel: discord.channel.TextChannel, role: discord.Role):
+            channel_list = [subscribed_channel for subscribed_channel in self.config.channels if subscribed_channel.id == channel.id]
+            channel_exists = len(channel_list) > 0
+
+            if not channel_exists:
+                await interaction.response.send_message(f'The channel <#{channel.id}> is not subscribed to any events.')
+                return
+            else:
+                channel_roles = self.config.channels[self.config.channels.index(channel_list[0])].roles
+
+                if role.id in channel_roles:
+                    await interaction.response.send_message(f"This role ping is already assigned to the channel <#{channel.id}>.")
+                    return
+                else:
+                    self.config.channels[self.config.channels.index(channel_list[0])].roles.append(role.id)
+
+            try:
+                self.config.save_config()
+            except Exception as e:
+                await interaction.response.send_message(f"The bot's subscription list could not be updated to add this role ping to the channel <#{channel.id}>: {e}\nRole ping addition cancelled.")
+                return
+            
+            await interaction.response.send_message(f'The channel <#{channel.id}> has been assigned to ping this role on future Jam Track events.')
+
+        @self.tree.command(name="remove_role", description="Remove a role ping from a channel's subscription messages")
+        @app_commands.describe(channel = "The channel to remove a role ping from")
+        @app_commands.describe(role = "The role to remove a ping for")
+        @app_commands.checks.has_permissions(administrator=True)
+        async def remove_role(interaction: discord.Interaction, channel: discord.channel.TextChannel, role: discord.Role):
+            channel_list = [subscribed_channel for subscribed_channel in self.config.channels if subscribed_channel.id == channel.id]
+            channel_exists = len(channel_list) > 0
+
+            if not channel_exists:
+                await interaction.response.send_message(f'The channel <#{channel.id}> is not subscribed to any events.')
+                return
+            else:
+                channel_roles = self.config.channels[self.config.channels.index(channel_list[0])].roles
+
+                if role.id in channel_roles:
+                    try:
+                        self.config.channels[self.config.channels.index(channel_list[0])].roles.remove(role.id)
+                    except ValueError as e:
+                        await interaction.response.send_message(f"This role ping could not be removed from the channel <#{channel.id}>: {e}\nRole ping removal cancelled.")
+                        return
+                else:
+                    await interaction.response.send_message(f"This role ping is not assigned to the channel <#{channel.id}>.")
+                    return
+
+            try:
+                self.config.save_config()
+            except Exception as e:
+                await interaction.response.send_message(f"The bot's subscription list could not be updated to remove this role ping from the channel <#{channel.id}>: {e}\nRole ping removal cancelled.")
+                return
+            
+            await interaction.response.send_message(f'The channel <#{channel.id}> has been assigned to not ping this role on future Jam Track events.')
+
+        @self.tree.command(name="subscriptions", description="View the subscriptions in this guild")
+        @app_commands.checks.has_permissions(administrator=True)
+        async def subscriptions(interaction: discord.Interaction):
+            embed = discord.Embed(title=f"Subscriptions for **{interaction.guild.name}**", color=0x8927A1)
+
+            event_names = {
+                'added': "Jam Track Added",
+                'removed': "Jam Track Removed",
+                'modified': "Jam Track Modified"
+            }
+
+            total_channels = 0
+
+            for channel_to_search in self.config.channels:
+                channel = self.get_channel(channel_to_search.id)
+
+                if channel:
+                    if channel.guild.id == interaction.guild.id:
+                        total_channels += 1
+                        events_content = "Events: " + ", ".join([event_names[event] for event in channel_to_search.events])
+                        role_content = ""
+                        if channel_to_search.roles:
+                            if len(channel_to_search.roles) > 0:
+                                role_content = "Roles: " + ", ".join([f'<@&{role.id}>' for role in channel_to_search.roles])
+                        embed.add_field(name=f"<#{channel_to_search.id}>", value=f"{events_content}\n{role_content}")
+
+            if total_channels < 1:
+                embed.add_field(name="There are no subscriptions in this guild.", value="")
+
+            await interaction.response.send_message(embed=embed)
+
+        async def on_subscription_error(interaction: discord.Interaction, error: app_commands.AppCommandError):
+            print(error)
+            if isinstance(error, app_commands.errors.MissingPermissions):
+                await interaction.response.send_message(content="You do not have the necessary permissions to run this command. Only administrators can use this command.", ephemeral=True)
+
+        subscribe.on_error = on_subscription_error
+        unsubscribe.on_error = on_subscription_error
+        add_event.on_error = on_subscription_error
+        remove_event.on_error = on_subscription_error
+        add_role.on_error = on_subscription_error
+        remove_role.on_error = on_subscription_error
+        subscriptions.on_error = on_subscription_error
+
+        # User DM subscriptions
+
+        @self.tree.command(name="dm_subscribe", description="Subscribe yourself to Jam Track events")
+        async def dm_subscribe(interaction: discord.Interaction):
+            user_list = [subscribed_user for subscribed_user in self.config.users if subscribed_user.id == interaction.user.id]
+            user_exists = len(user_list) > 0
+
+            event_names = {
+                'added': "Jam Track Added",
+                'removed': "Jam Track Removed",
+                'modified': "Jam Track Modified"
+            }
+
+            if not user_exists:
+                new_user = config.SubscriptionUser()
+                new_user.id = interaction.user.id
+                new_user.events = config.JamTrackEvent.get_all_events()
+                self.config.users.append(new_user)
+            else:
+                subscribed_user_events = self.config.users[self.config.users.index(user_list[0])].events
+                if len(subscribed_user_events) == len(config.JamTrackEvent.get_all_events()):
+                    await interaction.response.send_message(f"You're already subscribed to all Jam Track events.", ephemeral=True)
+                else:    
+                    await interaction.response.send_message(f"You're already subscribed to the events \"{'\", \"'.join([event_names[event] for event in subscribed_user_events])}\".", ephemeral=True)
+                return
+
+            try:
+                self.config.save_config()
+            except Exception as e:
+                await interaction.response.send_message(f"The bot's subscription list could not be updated to add you: {e}\nSubscription cancelled.", ephemeral=True)
+                return
+            
+            await interaction.response.send_message(f"You've been successfully added to the subscription list; I will now send you all Jam Track events.", ephemeral=True)
+            
+        @self.tree.command(name="dm_unsubscribe", description="Unsubscribe yourself from Jam Track events")
+        async def dm_unsubscribe(interaction: discord.Interaction):
+            user_list = [subscribed_user for subscribed_user in self.config.users if subscribed_user.id == interaction.user.id]
+            user_exists = len(user_list) > 0
+
+            if not user_exists:
+                await interaction.response.send_message(f"You are not subscribed to any Jam Track events.", ephemeral=True)
+                return
+            else:
+                try:
+                    self.config.users.remove(user_list[0])
+                except ValueError as e:
+                    await interaction.response.send_message(f"The bot's subscription list could not be updated to remove you: {e}\nUnsubscription cancelled.", ephemeral=True)
+                    return
+
+            try:
+                self.config.save_config()
+            except Exception as e:
+                await interaction.response.send_message(f"The bot's subscription list could not be updated to remove you: {e}\nUnsubscription cancelled.", ephemeral=True)
+                return
+            
+            await interaction.response.send_message(f"You've been successfully removed from the subscription list; I will no longer send you any Jam Track events.", ephemeral=True)
+
+        @self.tree.command(name="dm_add_event", description="Subscribe yourself to specific Jam Track events")
+        async def dm_add_event(interaction: discord.Interaction, event: config.JamTrackEvent):
+            user_list = [subscribed_user for subscribed_user in self.config.users if subscribed_user.id == interaction.user.id]
+            user_exists = len(user_list) > 0
+            chosen_event = config.JamTrackEvent[str(event).replace('JamTrackEvent.', '')].value
+
+            event_names = {
+                'added': "Jam Track Added",
+                'removed': "Jam Track Removed",
+                'modified': "Jam Track Modified"
+            }
+
+            if not user_exists:
+                new_user = config.SubscriptionUser()
+                new_user.id = interaction.user.id
+                new_user.events = [chosen_event]
+                self.config.users.append(new_user)
+            else:
+                subscribed_events = self.config.users[self.config.users.index(user_list[0])].events
+                if chosen_event in subscribed_events:
+                    await interaction.response.send_message(f'You are already subscribed to the event "{event_names[chosen_event]}".', ephemeral=True)
+                    return
+                else:
+                    self.config.users[self.config.users.index(user_list[0])].events.append(chosen_event)
+
+            try:
+                self.config.save_config()
+            except Exception as e:
+                await interaction.response.send_message(f"The bot's subscription list could not be updated to add the event \"{event_names[chosen_event]}\" to you: {e}\nEvent subscription cancelled.", ephemeral=True)
+                return
+            
+            await interaction.response.send_message(f'You have been subscribed to the event "{event_names[chosen_event]}".', ephemeral=True)
+
+        @self.tree.command(name="dm_remove_event", description="Unsubscribe yourself from Jam Track events")
+        async def dm_add_event(interaction: discord.Interaction, event: config.JamTrackEvent):
+            user_list = [subscribed_user for subscribed_user in self.config.users if subscribed_user.id == interaction.user.id]
+            user_exists = len(user_list) > 0
+            chosen_event = config.JamTrackEvent[str(event).replace('JamTrackEvent.', '')].value
+
+            event_names = {
+                'added': "Jam Track Added",
+                'removed': "Jam Track Removed",
+                'modified': "Jam Track Modified"
+            }
+
+            if not user_exists:
+                await interaction.response.send_message(f'You are not subscribed to any events.', ephemeral=True)
+                return
+            else:
+                subscribed_events = self.config.users[self.config.users.index(user_list[0])].events
+
+                if chosen_event in subscribed_events:
+                    try:
+                        self.config.users[self.config.users.index(user_list[0])].events.remove(chosen_event)
+
+                        # Remove the channel from the subscription list if it isnt subscribed to any events
+                        if len(self.config.users[self.config.users.index(user_list[0])].events) < 1:
+                            self.config.users.remove(user_list[0])
+                            self.config.save_config()
+                            await interaction.response.send_message(f"You have been removed from the subscription list because you are no longer subscribed to any events.", ephemeral=True)
+                            return
+
+                    except Exception as e:
+                        await interaction.response.send_message(f"The bot's subscription list could not be updated to remove the event \"{event_names[chosen_event]}\" from you: {e}\nEvent unsubscription cancelled.", ephemeral=True)
+                        return
+                else:
+                    await interaction.response.send_message(f'You are not subscribed to the event "{event_names[chosen_event]}".', ephemeral=True)
+                    return
+
+            try:
+                self.config.save_config()
+            except Exception as e:
+                await interaction.response.send_message(f"The bot's subscription list could not be updated to remove the event \"{event_names[chosen_event]}\" from you: {e}\nEvent unsubscription cancelled.", ephemeral=True)
+                return
+            
+            await interaction.response.send_message(f'You have been unsubscribed from the event "{event_names[chosen_event]}".', ephemeral=True)
 
 bot = FestivalInfoBot()


### PR DESCRIPTION
very fast and thorough review of this pr:

adds 11 commands, 7 of which can be used by administrators only
# admin commands

- subscribe
    allows administrators to subscribe a channel to track events
- unsubscribe
    same thing but opposite
- add event
    allows admins to add specific events to a channel
- remove event
    same thing but opposite
- add role
    allows admins to add role pings to messages in the channels
- remove role
   same thing but opposite
- subscriptions
   allows admins to view all the subscriptions in their guild

# normie commands
- dm subscribe
    subscribes you to jam track events to the bot
- dm unsubscribe
    same thing but opposite
- dm add event
    allows you to add specific events to your subscription
- dm remove event
     same thing but opposite

## terms ive used that may be unclear
an "event" or "jam track event" is one of these three: 
- when a track is removed
- when a track is added
- when a track is modified

a "subscription" is an action that binds a channel in the server for that channel to be sent jam track events

when using any of the "dm" commands, the bot will dm you the events instead of you having to view them in a server

all these commands were tested enough to qualify them as completely functional, and backups of the "database" are created