### PR TITLE
many fixes and commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ midi_files
 backups/
 Qt6Core.dll
 Qt6Gui.dll
+logs

--- a/bot/admin.py
+++ b/bot/admin.py
@@ -364,7 +364,7 @@ class TestCog(commands.Cog):
 
     @test_group.command(name="logs", description="Only the bot host can run this command. Tests logging functions and levels.")
     async def test_command(self, interaction: discord.Interaction):
-        if interaction.user.id != 734822755224125451:
+        if interaction.user.id != 960524988824313876:
             await interaction.response.send_message(content="You are not authorised to run this command.")
             return
         

--- a/bot/config.py
+++ b/bot/config.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 import enum
 import json
+import logging
 import os
 import copy
 
@@ -86,7 +87,7 @@ class Config:
 
         except Exception as e:
             open(self.file, 'w').write(previous_file_content)
-            print(f'RECOVERED CONFIG FILE: {e}\nRaising an Exception')
+            logging.critical(f'RECOVERED CONFIG FILE, Raising an Exception', exc_info=e)
             raise Exception
         
         with open(os.path.join(constants.BACKUP_FOLDER, self.create_backup_name()), 'w') as backup_file:

--- a/bot/embeds.py
+++ b/bot/embeds.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 import json
+import logging
 import subprocess
 import discord
 import requests
@@ -10,7 +11,7 @@ class DailyCommandEmbedHandler():
     def __init__(self) -> None:
         pass
 
-    def create_daily_embeds(self, daily_tracks, chunk_size=10):
+    def create_daily_embeds(self, daily_tracks, chunk_size=3):
         embeds = []
         
         for i in range(0, len(daily_tracks), chunk_size):
@@ -18,13 +19,12 @@ class DailyCommandEmbedHandler():
             chunk = daily_tracks[i:i + chunk_size]
             
             for entry in chunk:
-                active_since_display = f"<t:{entry['activeSince']}:R>" if entry['activeSince'] else "Unknown"
+                # active_since_display = f"<t:{entry['activeSince']}:R>" if entry['activeSince'] else "Unknown"
                 active_until_display = f"<t:{entry['activeUntil']}:R>" if entry['activeUntil'] else "Unknown"
                 
                 embed.add_field(
                     name="",
-                    value=f"**\\• {entry['title']}** - *{entry['artist']}*\n"
-                        f"`Added:` {active_since_display} - `Leaving:` {active_until_display}\n"
+                    value=f"**\\• {entry['title']}** - *{entry['artist']}* - Leaving: {active_until_display}\n"
                         f"```{entry['difficulty']}```\n",
                     inline=False
                 )
@@ -65,7 +65,7 @@ class LeaderboardEmbedHandler():
                     field_text += f"{rank:<5}{username:<18}{difficulty:<2}{accuracy:<5}{fc_status:<3}{stars:<7}{score:>8}"
 
                 except Exception as e:
-                    print(f"Error in leaderboard entry formatting: {e}")
+                    logging.error(f"Error in leaderboard entry formatting", exc_info=e)
                 field_text += '\n'
             field_text += '```'
 
@@ -111,7 +111,7 @@ class LeaderboardEmbedHandler():
 
                     session_field_text += f"{username:<18}{difficulty:<2}{accuracy:<5}{fc_status:<3}{stars:<7}{score:>8}\n"
                 except Exception as e:
-                    print(f"Error in session formatting: {e}")
+                    logging.error(f"Error in session formatting", exc_info=e)
 
             # Band data
             if not is_solo:
@@ -173,7 +173,7 @@ class StatsCommandEmbedHandler():
 
     def fetch_latest_github_commit_hash(self):
         repo_url = "https://api.github.com/repos/hmxmilohax/festivalinfobot/commits"
-        print(f'[GET] {repo_url}')
+        logging.debug(f'[GET] {repo_url}')
         response = requests.get(repo_url)
         if response.status_code == 200:
             latest_commit = response.json()[0]
@@ -190,7 +190,7 @@ class StatsCommandEmbedHandler():
             dirtyness = subprocess.check_output(['git', 'status', '--porcelain']).strip().decode('utf-8')
             return dirtyness, branch_name, commit_hash
         except Exception as e:
-            print(f"Error getting local commit hash: {e}")
+            logging.error(f"Error getting local commit info", exc_info=e)
             return "Unknown", "Unknown", "Unknown"
         
 class SearchEmbedHandler:

--- a/bot/embeds.py
+++ b/bot/embeds.py
@@ -19,8 +19,7 @@ class DailyCommandEmbedHandler():
             chunk = daily_tracks[i:i + chunk_size]
             
             for entry in chunk:
-                # active_since_display = f"<t:{entry['activeSince']}:R>" if entry['activeSince'] else "Unknown"
-                active_until_display = f"<t:{entry['activeUntil']}:R>" if entry['activeUntil'] else "Unknown"
+                active_until_display = discord.utils.format_dt(datetime.fromtimestamp(entry['activeUntil']), style="R") if entry['activeUntil'] else "Unknown"
                 
                 embed.add_field(
                     name="",
@@ -134,7 +133,7 @@ class LeaderboardEmbedHandler():
                     session_field_text += f"{name:<35}{total:>10}\n"
 
             session_field_text += '```'
-            embed.add_field(name=f"<t:{int(session['time'])}:R>", value=session_field_text, inline=False)
+            embed.add_field(name=discord.utils.format_dt(datetime.fromtimestamp(int(session['time'])), style="R"), value=session_field_text, inline=False)
 
         return embed
     
@@ -151,7 +150,7 @@ class StatsCommandEmbedHandler():
     def iso_to_unix_timestamp(self, iso_time_str):
         try:
             dt = datetime.fromisoformat(iso_time_str.replace('Z', '+00:00'))
-            return int(dt.timestamp())
+            return dt
         except ValueError:
             return None
         

--- a/bot/graph.py
+++ b/bot/graph.py
@@ -1,0 +1,234 @@
+import os
+import discord
+
+from bot import constants
+from bot.midi import MidiArchiveTools
+from bot.tracks import JamTrackHandler
+import graphs
+
+class GraphCommandsHandler():
+    def __init__(self) -> None:
+        self.jam_track_handler = JamTrackHandler()
+        self.midi_tool = MidiArchiveTools()
+
+    async def handle_pdi_interaction(self, interaction:discord.Interaction, song:str):
+        tracklist = self.jam_track_handler.get_jam_tracks()
+        if not tracklist:
+            await interaction.response.send_message(content=f"Could not get tracks.", ephemeral=True)
+            return
+
+        matched_tracks = self.jam_track_handler.fuzzy_search_tracks(tracklist, song)
+        if not matched_tracks:
+            await interaction.response.send_message(content=f"The search query \"{song}\" did not give any results.")
+            return
+
+        await interaction.response.defer() # Makes the bot say Thinking...
+        # From here on onwards, must use edit_original_response
+
+        user_id = interaction.user.id
+        session_hash = constants.generate_session_hash(user_id, song)  # Unique session identifier
+
+        # Use the first matched track
+        song_data = matched_tracks[0]
+        song_url = song_data['track'].get('mu')
+        album_art_url = song_data['track'].get('au')  # Fetch album art URL
+        track_title = song_data['track'].get('tt')
+        short_name = song_data['track'].get('sn')
+        artist_title = song_data['track'].get('an')
+
+        # Step 1: Download and decrypt the .dat file into a .mid file
+        local_midi_file = self.midi_tool.download_and_archive_midi_file(song_url, short_name)  # Download the .dat file
+
+        if not local_midi_file:
+            await interaction.edit_original_response(content=f"Failed to download the MIDI file for '{song}'.")
+            return
+
+        # Step 2: Decrypt the .dat file into a .mid file for processing
+        midi_file = self.midi_tool.decrypt_dat_file(local_midi_file, session_hash)
+        if not midi_file:
+            await interaction.edit_original_response(content=f"Failed to decrypt the .dat file for '{song}'.")
+            return
+        
+        image_path = f'{short_name}_pdi_graph_{session_hash}.png'
+        try:
+            graphs.generate_no_notes_pdi_chart(midi_path=midi_file, path=image_path, song_name=track_title, song_artist=artist_title)
+        except Exception as e:
+            await interaction.edit_original_response(content=f"Failed to generate the graph for '{song}'.")
+            return
+        
+        embed = discord.Embed(title=f"Note counts for\n**{track_title}** - *{artist_title}*", color=0x8927A1)
+        file = discord.File(os.path.join(constants.TEMP_FOLDER, image_path), filename=image_path)
+        embed.set_image(url=f"attachment://{image_path}")
+        embed.set_thumbnail(url=album_art_url)
+        embed.set_footer(text="Festival Tracker")
+        await interaction.edit_original_response(embed=embed, attachments=[file])
+
+        constants.delete_session_files(session_hash)
+
+    async def handle_lift_interaction(self, interaction:discord.Interaction, song:str):
+        tracklist = self.jam_track_handler.get_jam_tracks()
+        if not tracklist:
+            await interaction.response.send_message(content=f"Could not get tracks.", ephemeral=True)
+            return
+
+        matched_tracks = self.jam_track_handler.fuzzy_search_tracks(tracklist, song)
+        if not matched_tracks:
+            await interaction.response.send_message(content=f"The search query \"{song}\" did not give any results.")
+            return
+
+        await interaction.response.defer() # Makes the bot say Thinking...
+        # From here on onwards, must use edit_original_response
+
+        user_id = interaction.user.id
+        session_hash = constants.generate_session_hash(user_id, song)  # Unique session identifier
+
+        # Use the first matched track
+        song_data = matched_tracks[0]
+        song_url = song_data['track'].get('mu')
+        album_art_url = song_data['track'].get('au')  # Fetch album art URL
+        track_title = song_data['track'].get('tt')
+        short_name = song_data['track'].get('sn')
+        artist_title = song_data['track'].get('an')
+
+        # Step 1: Download and decrypt the .dat file into a .mid file
+        local_midi_file = self.midi_tool.download_and_archive_midi_file(song_url, short_name)  # Download the .dat file
+
+        if not local_midi_file:
+            await interaction.edit_original_response(content=f"Failed to download the MIDI file for '{song}'.")
+            return
+
+        # Step 2: Decrypt the .dat file into a .mid file for processing
+        midi_file = self.midi_tool.decrypt_dat_file(local_midi_file, session_hash)
+        if not midi_file:
+            await interaction.edit_original_response(content=f"Failed to decrypt the .dat file for '{song}'.")
+            return
+        
+        image_path = f'{short_name}_lift_graph_{session_hash}.png'
+        try:
+            graphs.generate_no_notes_pdi_chart(midi_path=midi_file, path=image_path, song_name=track_title, song_artist=artist_title, lifts=True)
+        except Exception as e:
+            await interaction.edit_original_response(content=f"Failed to generate the graph for '{song}': {e}.")
+            return
+        
+        embed = discord.Embed(title=f"Lift counts for\n**{track_title}** - *{artist_title}*", color=0x8927A1)
+        file = discord.File(os.path.join(constants.TEMP_FOLDER, image_path), filename=image_path)
+        embed.set_image(url=f"attachment://{image_path}")
+        embed.set_thumbnail(url=album_art_url)
+        embed.set_footer(text="Festival Tracker")
+        await interaction.edit_original_response(embed=embed, attachments=[file])
+
+        constants.delete_session_files(session_hash)
+
+    async def handle_nps_interaction(self, interaction:discord.Interaction, song:str, instrument : constants.Instruments, difficulty : constants.Difficulties = constants.Difficulties.Expert):
+        chosen_instrument = constants.Instruments[str(instrument).replace('Instruments.', '')].value
+        chosen_diff = constants.Difficulties[str(difficulty).replace('Difficulties.', '')].value
+
+        tracklist = self.jam_track_handler.get_jam_tracks()
+        if not tracklist:
+            await interaction.response.send_message(content=f"Could not get tracks.", ephemeral=True)
+            return
+
+        matched_tracks = self.jam_track_handler.fuzzy_search_tracks(tracklist, song)
+        if not matched_tracks:
+            await interaction.response.send_message(content=f"The search query \"{song}\" did not give any results.")
+            return
+
+        await interaction.response.defer() # Makes the bot say Thinking...
+        # From here on onwards, must use edit_original_response
+
+        user_id = interaction.user.id
+        session_hash = constants.generate_session_hash(user_id, song)  # Unique session identifier
+
+        # Use the first matched track
+        song_data = matched_tracks[0]
+        song_url = song_data['track'].get('mu')
+        album_art_url = song_data['track'].get('au')  # Fetch album art URL
+        track_title = song_data['track'].get('tt')
+        short_name = song_data['track'].get('sn')
+        artist_title = song_data['track'].get('an')
+
+        # Step 1: Download and decrypt the .dat file into a .mid file
+        local_midi_file = self.midi_tool.download_and_archive_midi_file(song_url, short_name)  # Download the .dat file
+
+        if not local_midi_file:
+            await interaction.edit_original_response(content=f"Failed to download the MIDI file for '{song}'.")
+            return
+
+        # Step 2: Decrypt the .dat file into a .mid file for processing
+        midi_file = self.midi_tool.decrypt_dat_file(local_midi_file, session_hash)
+        if not midi_file:
+            await interaction.edit_original_response(content=f"Failed to decrypt the .dat file for '{song}'.")
+            return
+        
+        image_path = f'{short_name}_nps_graph_{session_hash}.png'
+        try:
+            graphs.generate_nps_chart(midi_path=midi_file, path=image_path, inst=chosen_instrument, diff=chosen_diff, song_name=track_title, song_artist=artist_title)
+        except Exception as e:
+            await interaction.edit_original_response(content=f"Failed to generate the graph for '{song}': {e}.")
+            return
+        
+        embed = discord.Embed(title=f"NPS Graph for\n**{track_title}** - *{artist_title}*", color=0x8927A1)
+        file = discord.File(os.path.join(constants.TEMP_FOLDER, image_path), filename=image_path)
+        embed.set_image(url=f"attachment://{image_path}")
+        embed.set_thumbnail(url=album_art_url)
+        embed.set_footer(text="Festival Tracker")
+        await interaction.edit_original_response(embed=embed, attachments=[file])
+
+        constants.delete_session_files(session_hash)
+
+    async def handle_lanes_interaction(self, interaction:discord.Interaction, song:str, instrument : constants.Instruments, difficulty : constants.Difficulties = constants.Difficulties.Expert):
+        chosen_instrument = constants.Instruments[str(instrument).replace('Instruments.', '')].value
+        chosen_diff = constants.Difficulties[str(difficulty).replace('Difficulties.', '')].value
+
+        tracklist = self.jam_track_handler.get_jam_tracks()
+        if not tracklist:
+            await interaction.response.send_message(content=f"Could not get tracks.", ephemeral=True)
+            return
+
+        matched_tracks = self.jam_track_handler.fuzzy_search_tracks(tracklist, song)
+        if not matched_tracks:
+            await interaction.response.send_message(content=f"The search query \"{song}\" did not give any results.")
+            return
+
+        await interaction.response.defer() # Makes the bot say Thinking...
+        # From here on onwards, must use edit_original_response
+
+        user_id = interaction.user.id
+        session_hash = constants.generate_session_hash(user_id, song)  # Unique session identifier
+
+        # Use the first matched track
+        song_data = matched_tracks[0]
+        song_url = song_data['track'].get('mu')
+        album_art_url = song_data['track'].get('au')  # Fetch album art URL
+        track_title = song_data['track'].get('tt')
+        short_name = song_data['track'].get('sn')
+        artist_title = song_data['track'].get('an')
+
+        # Step 1: Download and decrypt the .dat file into a .mid file
+        local_midi_file = self.midi_tool.download_and_archive_midi_file(song_url, short_name)  # Download the .dat file
+
+        if not local_midi_file:
+            await interaction.edit_original_response(content=f"Failed to download the MIDI file for '{song}'.")
+            return
+
+        # Step 2: Decrypt the .dat file into a .mid file for processing
+        midi_file = self.midi_tool.decrypt_dat_file(local_midi_file, session_hash)
+        if not midi_file:
+            await interaction.edit_original_response(content=f"Failed to decrypt the .dat file for '{song}'.")
+            return
+        
+        image_path = f'{short_name}_lanes_graph_{session_hash}.png'
+        try:
+            graphs.generate_lanes_chart(midi_path=midi_file, spath=image_path, inst=chosen_instrument, diff=chosen_diff, song_name=track_title, song_artist=artist_title)
+        except Exception as e:
+            await interaction.edit_original_response(content=f"Failed to generate the graph for '{song}': {e}.")
+            return
+        
+        embed = discord.Embed(title=f"Notes per lane graph for\n**{track_title}** - *{artist_title}*", color=0x8927A1)
+        file = discord.File(os.path.join(constants.TEMP_FOLDER, image_path), filename=image_path)
+        embed.set_image(url=f"attachment://{image_path}")
+        embed.set_thumbnail(url=album_art_url)
+        embed.set_footer(text="Festival Tracker")
+        await interaction.edit_original_response(embed=embed, attachments=[file])
+
+        constants.delete_session_files(session_hash)

--- a/bot/helpers.py
+++ b/bot/helpers.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timezone
+import logging
 import random
 
 import discord
@@ -13,7 +14,7 @@ class DailyCommandHandler:
 
     def fetch_daily_shortnames(self):
         try:
-            print(f'[GET] {constants.DAILY_API}')
+            logging.debug(f'[GET] {constants.DAILY_API}')
             response = requests.get(constants.DAILY_API)
             data = response.json()
 
@@ -29,7 +30,7 @@ class DailyCommandHandler:
             valid_states.sort(key=lambda x: datetime.fromisoformat(x['validFrom'].replace('Z', '+00:00')), reverse=True)
 
             if not valid_states:
-                print("No valid states found")
+                logging.error("No valid states found")
                 return None
 
             # Get the activeEvents from the most recent valid state
@@ -56,7 +57,7 @@ class DailyCommandHandler:
 
             return daily_tracks
         except Exception as e:
-            print(e)
+            logging.error(exc_info=e)
             return {}
     
     def convert_iso_to_timestamp(self, event_data):
@@ -160,7 +161,7 @@ class ShopCommandHandler:
 
     def fetch_shop_tracks(self):
         try:
-            print(f'[GET] {constants.SHOP_API}')
+            logging.debug(f'[GET] {constants.SHOP_API}')
             response = requests.get(constants.SHOP_API)
             data = response.json()
 
@@ -191,13 +192,13 @@ class ShopCommandHandler:
                                     }
 
                 if not available_tracks:
-                    print('No tracks found in the shop.')
+                    logging.error('No tracks found in the shop.')
                     return None
 
                 return available_tracks  # Return dictionary keyed by devName
 
         except Exception as e:
-            print(f'Error fetching shop tracks: {e}')
+            logging.error(f'Error fetching shop tracks', exc_info=e)
             return None
         
 class TracklistHandler:

--- a/bot/history.py
+++ b/bot/history.py
@@ -2,6 +2,7 @@ import asyncio
 from datetime import datetime, timezone
 import hashlib
 import json
+import logging
 import os
 import shutil
 import subprocess
@@ -15,9 +16,11 @@ from bot.embeds import SearchEmbedHandler, StatsCommandEmbedHandler
 from bot.midi import MidiArchiveTools
 from bot.tracks import JamTrackHandler
 
+import sparks_tracks
+
 def save_known_songs_to_disk(songs):
     # Fetch jam tracks using the API call
-    print(f'[GET] {constants.CONTENT_API}')
+    logging.debug(f'[GET] {constants.CONTENT_API}')
     response = requests.get(constants.CONTENT_API)
     response.raise_for_status()
 
@@ -66,23 +69,23 @@ def save_known_songs_to_disk(songs):
     # Always update the root known_tracks.json (for full songs) or known_songs.json (for shortnames)
     with open(known_tracks_file_path, 'w') as known_tracks_file:
         json.dump(current_tracks_data, known_tracks_file, indent=4)
-    print(f"Updated: {known_tracks_file_path}")
+    logging.info(f"Updated: {known_tracks_file_path}")
 
     with open(known_songs_file_path, 'w') as known_songs_file:
         json.dump(current_songs_data, known_songs_file, indent=4)
-    print(f"Updated: {known_songs_file_path}")
+    logging.info(f"Updated: {known_songs_file_path}")
 
     # Check if any of the 3 most recent files match the current data
     for content in recent_files_content:
         if json.dumps(content, sort_keys=True) == json.dumps(data, sort_keys=True):
-            print(f"No new sparks-tracks.json changes to save. Matches {file_name}.")
+            logging.info(f"No new sparks-tracks.json changes to save. Matches {file_name}.")
             return  # Exit without saving if there's a match
 
     # Save the new JSON file if no match was found
     file_path = os.path.join(folder_path, file_name)
     with open(file_path, 'w') as file:
         json.dump(data, file, indent=4)
-    print(f"New file saved as {file_name}")
+    logging.info(f"New file saved as {file_name}")
 
 def load_known_songs_from_disk(shortnames:bool = False):
     path = constants.SONGS_FILE if not shortnames else constants.SHORTNAME_FILE
@@ -102,14 +105,14 @@ class HistoryHandler():
         midi_file_changes = []
         seen_midi_files = {}
         json_files = [f for f in json_files if f.endswith('.json')]
-        print(f"Total JSON files to process: {len(json_files)}")
+        logging.debug(f"Total JSON files to process: {len(json_files)}")
 
         try:
             for idx, json_file in enumerate(json_files):
                 file_path = os.path.join(constants.LOCAL_JSON_FOLDER, json_file)
                 file_content = constants.load_json_from_file(file_path)
                 if not file_content:
-                    print(f"Failed to load content from {file_path}, skipping to next file.")
+                    logging.error(f"Failed to load content from {file_path}, skipping to next file.")
                     continue
 
                 song_data = file_content.get(shortname)
@@ -125,21 +128,21 @@ class HistoryHandler():
                     midi_file_changes.append((last_modified, local_midi_file))
 
         except Exception as e:
-            print(f"Error processing {json_file}: {e}")
+            logging.error(f"Error processing {json_file}", exc_info=e)
         
         return midi_file_changes
     
     def track_meta_changes(self, json_files, shortname, session_hash):
         changes = []
         json_files = [f for f in json_files if f.endswith('.json')]
-        print(f"Total JSON files to process: {len(json_files)}")
+        logging.debug(f"Total JSON files to process: {len(json_files)}")
 
         try:
             for idx, json_file in enumerate(json_files):
                 file_path = os.path.join(constants.LOCAL_JSON_FOLDER, json_file)
                 file_content = constants.load_json_from_file(file_path)
                 if not file_content:
-                    print(f"Failed to load content from {file_path}, skipping to next file.")
+                    logging.error(f"Failed to load content from {file_path}, skipping to next file.")
                     continue
 
                 song_data = file_content.get(shortname)
@@ -156,7 +159,7 @@ class HistoryHandler():
                         changes.append((last_modified, change))
 
         except Exception as e:
-            print(f"Error processing {json_file}: {e}")
+            logging.error(f"Error processing {json_file}", exc_info=e)
 
         grouped_changes = {}
         for item in changes:
@@ -193,7 +196,7 @@ class HistoryHandler():
                     try:
                         await channel.send(content=f"Comparison failed with error: {result.stderr}")
                     except Exception as e:
-                        print(f"Error sending message to channel {channel.id}: {e}")
+                        logging.error(f"Error sending message to channel {channel.id}", exc_info=e)
 
                 return
 
@@ -212,7 +215,7 @@ class HistoryHandler():
                         try:
                             await channel.send(content=f"Found {len(comparison_images)} MIDI Track changes:")
                         except Exception as e:
-                            print(f"Error sending message to channel {channel.id}: {e}")
+                            logging.error(f"Error sending message to channel {channel.id}", exc_info=e)
 
                     # do not use edit_original_response here
                     for image in comparison_images:
@@ -232,10 +235,11 @@ class HistoryHandler():
                             else:
                                 img_message = await channel.send(embed=embed, file=file)
 
-                            if img_message.channel.is_news():
-                                await img_message.publish()
+                            if isinstance(img_message.channel, discord.TextChannel):
+                                if img_message.channel.is_news():
+                                    await img_message.publish()
                         except Exception as e:
-                            print(f"Error sending embed to channel {channel.id if channel else 'N/A'}: {e}")
+                            logging.error(f"Error sending embed to channel {channel.id if channel else 'N/A'}", exc_info=e)
                     constants.delete_session_files(session_hash)
                 else:
                     if not channel:
@@ -243,10 +247,11 @@ class HistoryHandler():
                     else:
                         try:
                             message = await channel.send(content=f"Comparison between `{last_modified_old_str}` and `{last_modified_new_str}` shows seemingly no visual changes.")
-                            if message.channel.is_news():
-                                await message.publish()
+                            if isinstance(message.channel, discord.TextChannel):
+                                if message.channel.is_news():
+                                    await message.publish()
                         except Exception as e:
-                            print(f"Error sending message to channel {channel.id}: {e}")
+                            logging.error(f"Error sending message to channel {channel.id}", exc_info=e)
                     constants.delete_session_files(session_hash)
             else:
                 if not channel:
@@ -255,7 +260,7 @@ class HistoryHandler():
                     try:
                         message = await channel.send(content="MIDI comparison did not complete successfully.")
                     except Exception as e:
-                        print(f"Error sending message to channel {channel.id}: {e}")
+                        logging.error(f"Error sending message to channel {channel.id}", exc_info=e)
                 constants.delete_session_files(session_hash)
         else:
             if not channel:
@@ -264,7 +269,7 @@ class HistoryHandler():
                 try:
                     await channel.send(content="Failed to decrypt MIDI files.")
                 except Exception as e:
-                    print(f"Error sending message to channel {channel.id}: {e}")
+                    logging.error(f"Error sending message to channel {channel.id}", exc_info=e)
             constants.delete_session_files(session_hash)
 
     def fetch_local_history(self):
@@ -274,13 +279,13 @@ class HistoryHandler():
                 if file_name.endswith('.json'):
                     json_files.append(file_name)
         except Exception as e:
-            print(f"Error reading local JSON files: {e}")
+            logging.error(f"Error reading local JSON files", exc_info=e)
         return sorted(json_files)
 
     async def handle_interaction(self, interaction: discord.Interaction, song:str, channel : discord.channel.TextChannel = None, use_channel:bool = False):
         user_id = interaction.user.id
         session_hash = constants.generate_session_hash(user_id, song)
-        print(f"Generated session hash: {session_hash} for user: {user_id}")
+        logging.debug(f"Generated session hash: {session_hash} for user: {user_id}")
 
         # Fetch track data from the API
         tracks = self.jam_track_handler.get_jam_tracks()
@@ -291,20 +296,20 @@ class HistoryHandler():
                 try:
                     await channel.send(content="Could not fetch tracks.")
                 except Exception as e:
-                    print(f"Error sending message to channel {channel.id}: {e}")
+                    logging.error(f"Error sending message to channel {channel.id}", exc_info=e)
             return
 
         # Perform fuzzy search to find the matching song
         matched_tracks = self.jam_track_handler.fuzzy_search_tracks(tracks, song)
         if not matched_tracks:
-            print(f"No tracks found matching {song}.")
+            logging.error(f"No tracks found matching {song}.")
             if not use_channel:
                 await interaction.response.send_message(content=f"No tracks found for '{song}'.")
             else:
                 try:
                     await channel.send(content=f"No tracks found for '{song}'.")
                 except Exception as e:
-                    print(f"Error sending message to channel {channel.id}: {e}")
+                    logging.error(f"Error sending message to channel {channel.id}", exc_info=e)
             return
         
         if not use_channel:
@@ -325,11 +330,11 @@ class HistoryHandler():
                 try:
                     await channel.send(content=f"No local history files found.")
                 except Exception as e:
-                    print(f"Error sending message to channel {channel.id}: {e}")
+                    logging.error(f"Error sending message to channel {channel.id}", exc_info=e)
             return
 
         midi_file_changes = self.track_midi_changes(json_files, shortname, session_hash)
-        print(f"Found {len(midi_file_changes)} MIDI file changes for {shortname}.")
+        logging.info(f"Found {len(midi_file_changes)} MIDI file changes for {shortname}.")
 
         if len(midi_file_changes) <= 1:
             if not use_channel:
@@ -338,7 +343,7 @@ class HistoryHandler():
                 try:
                     await channel.send(content=f"No changes detected for the song **{actual_title}** - *{actual_artist}*\nOnly one version of the MIDI file exists.")
                 except Exception as e:
-                    print(f"Error sending message to channel {channel.id}: {e}")
+                    logging.error(f"Error sending message to channel {channel.id}", exc_info=e)
             return
 
         for i in range(1, len(midi_file_changes)):
@@ -358,7 +363,7 @@ class HistoryHandler():
     async def handle_metahistory_interaction(self, interaction: discord.Interaction, song:str):
         user_id = interaction.user.id
         session_hash = constants.generate_session_hash(user_id, song)
-        print(f"Generated session hash: {session_hash} for user: {user_id}")
+        logging.debug(f"Generated session hash: {session_hash} for user: {user_id}")
 
         # Fetch track data from the API
         tracks = self.jam_track_handler.get_jam_tracks()
@@ -369,7 +374,7 @@ class HistoryHandler():
         # Perform fuzzy search to find the matching song
         matched_tracks = self.jam_track_handler.fuzzy_search_tracks(tracks, song)
         if not matched_tracks:
-            print(f"No tracks found matching {song}.")
+            logging.error(f"No tracks found matching {song}.")
             await interaction.response.send_message(content=f"No tracks found for '{song}'.")
             return
         
@@ -451,7 +456,7 @@ class HistoryHandler():
     async def handle_interaction(self, interaction: discord.Interaction, song:str, channel : discord.channel.TextChannel = None, use_channel:bool = False):
         user_id = interaction.user.id
         session_hash = constants.generate_session_hash(user_id, song)
-        print(f"Generated session hash: {session_hash} for user: {user_id}")
+        logging.info(f"Generated session hash: {session_hash} for user: {user_id}")
 
         # Fetch track data from the API
         tracks = self.jam_track_handler.get_jam_tracks()
@@ -462,7 +467,7 @@ class HistoryHandler():
         # Perform fuzzy search to find the matching song
         matched_tracks = self.jam_track_handler.fuzzy_search_tracks(tracks, song)
         if not matched_tracks:
-            print(f"No tracks found matching {song}.")
+            logging.error(f"No tracks found matching {song}.")
             await interaction.response.send_message(content=f"No tracks found for '{song}'.")
             return
         
@@ -482,7 +487,7 @@ class HistoryHandler():
             return
 
         midi_file_changes = self.track_midi_changes(json_files, shortname, session_hash)
-        print(f"Found {len(midi_file_changes)} MIDI file changes for {shortname}.")
+        logging.info(f"Found {len(midi_file_changes)} MIDI file changes for {shortname}.")
 
         if len(midi_file_changes) <= 1:
             await interaction.edit_original_response(content=f"No changes detected for the song **{actual_title}** - *{actual_artist}*\nOnly one version of the MIDI file exists.")
@@ -509,12 +514,12 @@ class LoopCheckHandler():
 
     async def handle_task(self):
         if not self.bot.config:
-            print(f"No config provided; skipping the {self.bot.CHECK_FOR_SONGS_INTERVAL}-minute probe.")
+            logging.warning(f"No config provided; skipping the {self.bot.CHECK_FOR_SONGS_INTERVAL}-minute probe.")
             return
 
         # Remove duplicates from self.bot.config.channels and self.bot.config.users
         def remove_duplicates_by_id(items):
-            print("Attempting to remove duplicates...")
+            logging.debug("Attempting to remove duplicates...")
             seen_ids = set()
             unique_items = []
             for item in items:
@@ -531,25 +536,25 @@ class LoopCheckHandler():
         self.bot.config.users = remove_duplicates_by_id(self.bot.config.users)
 
         if len(self.bot.config.channels) != original_channel_count or len(self.bot.config.users) != original_user_count:
-            print("Duplicates found in config; cleaning up and saving.")
+            logging.warning("Duplicates found in config; cleaning up and saving.")
             self.bot.config.save_config()
 
         session_hash = constants.generate_session_hash(self.bot.start_time, self.bot.start_time)  # Unique session identifier
 
-        print("Checking for new songs...")
+        logging.info("Checking for new songs...")
 
         # Run sparks_tracks.py alongside this script
         try:
-            subprocess.Popen(["python", "sparks_tracks.py"])
-            print("Running sparks_tracks.py")
+            sparks_tracks.main()
+            logging.debug("Running sparks_tracks.py")
         except Exception as e:
-            print(f"Failed to run sparks_tracks.py: {e}")
+            logging.error(f"Failed to run sparks_tracks.py", exc_info=e)
 
         # Fetch current jam tracks
         tracks = self.jam_track_handler.get_jam_tracks()
 
         if not tracks:
-            print('Could not fetch tracks.')
+            logging.error('Could not fetch tracks.')
             return
 
         # Dynamically reload known tracks and shortnames from disk each time the task runs
@@ -587,7 +592,7 @@ class LoopCheckHandler():
         for channel_to_send in combined_channels:
             # check for duplicates
             if channel_to_send.id in already_sent_to:
-                print(f'DUPLICATE DETECTED: {channel_to_send.id}')
+                logging.warning(f'DUPLICATE DETECTED: {channel_to_send.id}')
                 duplicates.append(channel_to_send.id)
                 continue
             else:
@@ -601,7 +606,7 @@ class LoopCheckHandler():
                 channel = None
 
             if not channel:
-                print(f"Channel with ID {channel_to_send.id} not found.")
+                logging.error(f"Channel with ID {channel_to_send.id} not found.")
                 continue
 
             content = ""
@@ -612,7 +617,7 @@ class LoopCheckHandler():
                 content = " ".join(role_pings)
 
             if new_songs and JamTrackEvent.Added.value in channel_to_send.events:
-                print(f"New songs detected!")
+                logging.info(f"New songs detected!")
                 for new_song in new_songs:
                     embed = self.embed_handler.generate_track_embed(new_song, is_new=True)
                     try:
@@ -622,11 +627,11 @@ class LoopCheckHandler():
                                 await message.publish()
                         await asyncio.sleep(2)
                     except Exception as e:
-                        print(f"Error sending message to channel {channel.id}: {e}")
+                        logging.error(f"Error sending message to channel {channel.id}", exc_info=e)
                 save_known_songs_to_disk(tracks)
 
             if removed_songs and JamTrackEvent.Removed.value in channel_to_send.events:
-                print(f"Removed songs detected!")
+                logging.info(f"Removed songs detected!")
                 for removed_song in removed_songs:
                     embed = self.embed_handler.generate_track_embed(removed_song, is_removed=True)
                     try:
@@ -636,11 +641,11 @@ class LoopCheckHandler():
                                 await message.publish()
                         await asyncio.sleep(2)
                     except Exception as e:
-                        print(f"Error sending message to channel {channel.id}: {e}")
+                        logging.error(f"Error sending message to channel {channel.id}", exc_info=e)
                 save_known_songs_to_disk(tracks)
 
             if modified_songs and JamTrackEvent.Modified.value in channel_to_send.events:
-                print(f"Modified songs detected!")
+                logging.info(f"Modified songs detected!")
                 for old_song, new_song in modified_songs:
                     old_url = old_song['track'].get('mu', '')
                     new_url = new_song['track'].get('mu', '')
@@ -654,12 +659,12 @@ class LoopCheckHandler():
                     local_midi_file_new = self.midi_tools.download_and_archive_midi_file(new_url, short_name)
 
                     if (old_url != new_url) and self.bot.DECRYPTION_ALLOWED and self.bot.CHART_COMPARING_ALLOWED:
-                        print(f"Chart URL changed:")
-                        print(f"Old: {local_midi_file_old}")
-                        print(f"New: {local_midi_file_new}")
+                        logging.info(f"Chart URL changed:")
+                        logging.info(f"Old: {local_midi_file_old}")
+                        logging.info(f"New: {local_midi_file_new}")
 
                         # Pass the track name to the process_chart_url_change function
-                        print(f"Running process_chart_url_change for {local_midi_file_old} and {local_midi_file_new}")
+                        logging.debug(f"Running process_chart_url_change for {local_midi_file_old} and {local_midi_file_new}")
                         await self.history_handler.process_chart_url_change(old_url=local_midi_file_old, new_url=local_midi_file_new, interaction=None, track_name=short_name, song_title=track_name, artist_name=artist_name, album_art_url=album_art_url, last_modified_old=last_modified_old, last_modified_new=last_modified_new, session_hash=session_hash, channel=channel)
 
                     embed = self.embed_handler.generate_modified_track_embed(old=old_song, new=new_song)
@@ -670,12 +675,13 @@ class LoopCheckHandler():
                                 await message.publish()
                         await asyncio.sleep(2)
                     except Exception as e:
-                        print(f"Error sending message to channel {channel.id}: {e}")
+                        logging.error(f"Error sending message to channel {channel.id}", exc_info=e)
                 save_known_songs_to_disk(tracks)
 
         if len(duplicates) > 0:
-            print('Warning: Duplicates detected!')
-            print('Please check!\n' * 10)
-            print('Duplicates: ' + ', '.join([str(_id) for _id in duplicates]))
+            logging.warning('Duplicates detected!')
+            for i in range(10):
+                logging.warning('Please check!')
+            logging.warning('Duplicates: ' + ', '.join([str(_id) for _id in duplicates]))
 
-        print(f"Done checking for new songs:\nNew: {len(new_songs)}\nModified: {len(modified_songs)}\nRemoved: {len(removed_songs)}")
+        logging.info(f"Done checking for new songs: New: {len(new_songs)} | Modified: {len(modified_songs)} | Removed: {len(removed_songs)}")

--- a/bot/leaderboard.py
+++ b/bot/leaderboard.py
@@ -75,7 +75,7 @@ class LeaderboardCommandHandler:
             else:
                 specific_entries = []
                 specific_entries.extend([entry for entry in leaderboard_entries if entry['rank'] == rank] if rank else [])
-                specific_entries.extend([entry for entry in leaderboard_entries if username.lower() in entry['userName'].lower()] if username else [])
+                specific_entries.extend([entry for entry in leaderboard_entries if username.lower() in str(entry.get('userName', 'N/A')).lower()] if username else [])
                 specific_entries.extend([entry for entry in leaderboard_entries if entry['teamId'] == account_id] if account_id else [])
                 specific_entries_unique = []
                 for entry in specific_entries: 

--- a/bot/leaderboard.py
+++ b/bot/leaderboard.py
@@ -1,3 +1,4 @@
+import logging
 import requests
 import bot.constants as constants
 from bot.embeds import LeaderboardEmbedHandler
@@ -12,7 +13,7 @@ class LeaderboardCommandHandler:
 
     def fetch_leaderboard_of_track(self, shortname:str, instrument:constants.Instrument):
         season_url = f'{constants.LEADERBOARD_DB_URL}meta.json'
-        print(f'[GET] {season_url}')
+        logging.debug(f'[GET] {season_url}')
 
         season_number_request = requests.get(season_url)
         current_season_number = season_number_request.json()['season']
@@ -24,7 +25,7 @@ class LeaderboardCommandHandler:
         while (fetched_pages < 5):
             json_url = f'{song_url}{instrument.lb_code}_{fetched_pages}.json'
             try:
-                print(f'[GET] {json_url}')
+                logging.debug(f'[GET] {json_url}')
 
                 response = requests.get(json_url)
                 response.raise_for_status()
@@ -32,7 +33,7 @@ class LeaderboardCommandHandler:
                 fetched_entries.extend(data['entries'])
                 fetched_pages += 1
             except Exception as e: # No more entries, the leaderboard isn't full yet
-                print(f'There aren\'t enough entries to fetch: {e}')
+                logging.warning(f'There aren\'t enough entries to fetch', exc_info=e)
                 return fetched_entries
         else: # 5 pages have been fetched
             return fetched_entries

--- a/bot/log.py
+++ b/bot/log.py
@@ -1,0 +1,118 @@
+import logging
+import logging.handlers
+import sys
+
+from pathlib import Path
+
+BLACK = "\033[0;30m"
+RED = "\033[0;31m"
+GREEN = "\033[0;32m"
+BROWN = "\033[0;33m"
+BLUE = "\033[0;34m"
+PURPLE = "\033[0;35m"
+CYAN = "\033[0;36m"
+LIGHT_GRAY = "\033[0;37m"
+DARK_GRAY = "\033[1;30m"
+LIGHT_RED = "\033[1;31m"
+LIGHT_GREEN = "\033[1;32m"
+YELLOW = "\033[1;33m"
+LIGHT_BLUE = "\033[1;34m"
+LIGHT_PURPLE = "\033[1;35m"
+LIGHT_CYAN = "\033[1;36m"
+LIGHT_WHITE = "\033[1;37m"
+BOLD = "\033[1m"
+FAINT = "\033[2m"
+ITALIC = "\033[3m"
+UNDERLINE = "\033[4m"
+BLINK = "\033[5m"
+NEGATIVE = "\033[7m"
+CROSSED = "\033[9m"
+END = "\033[0m"
+
+class CustomHandler(logging.StreamHandler):
+    def emit(self, record):
+        log_entry = self.format(record)
+        # Print our logs to the console, since thats how it works
+        print(log_entry)
+
+class CustomFormatter(logging.Formatter):
+    def __init__(self, no_ansi = False, *args, **kwargs):
+        self.no_ansi = no_ansi
+        super().__init__(*args, **kwargs)
+
+    def set_fixed_size(self, string:str, intended_length: int = 30, right_to_left = False):
+        if len(string) > intended_length:
+            return string[:intended_length - 3] + '...'
+        else:
+            if right_to_left:
+                return (' ' * (intended_length - len(string))) + string
+            return string + (' ' * (intended_length - len(string)))
+
+    def format(self, record):
+        # Combine filename and line number into one field with padding
+        file_line = f'{record.filename}:{record.lineno}'
+        # Set a fixed width for the combined field (e.g., 30 characters)
+        padded_file_line = self.set_fixed_size(file_line, 25)
+
+        level_color = YELLOW
+        if record.levelname == 'INFO':
+            level_color = CYAN
+        if record.levelname == 'DEBUG':
+            level_color = BLUE
+        if record.levelname == 'WARNING':
+            level_color = f'{BOLD}{BROWN}'
+        if record.levelname == 'ERROR':
+            level_color = f'{BOLD}{RED}' 
+        if record.levelname == 'CRITICAL':
+            level_color = f'{BOLD}{PURPLE}'
+        
+        log_format = f"{GREEN}{self.formatTime(record, self.datefmt)}{END} {BLUE}{padded_file_line}{END} {level_color}%(levelname)-8s {END} %(message)s"
+        if self.no_ansi:
+            log_format = f"{self.formatTime(record, self.datefmt)} {padded_file_line} %(levelname)-8s %(message)s"
+        
+        # Update the format dynamically for this record
+        formatter = logging.Formatter(log_format, "%Y-%m-%d %H:%M:%S")
+        return formatter.format(record)
+
+def setup() -> logging.RootLogger:
+    # logger config
+    logger = logging.getLogger()
+
+    # Disable debug messages on these dumb libraries!
+    if '-discord-debug' not in sys.argv:
+        logging.getLogger('discord').setLevel(logging.INFO)
+    logging.getLogger('urllib3').setLevel(logging.INFO)
+    logging.getLogger('matplotlib').setLevel(logging.INFO)
+
+    # Set ourselves as the VIP.
+    logger.setLevel(logging.DEBUG)
+
+    try: Path("logs").mkdir(exist_ok=True)
+    except: pass
+        
+    # file handler
+    log_file = f"logs/festivalinfobot.log"
+    # Every 40mb another file will be created (?)
+    file_handler = logging.handlers.RotatingFileHandler(log_file, backupCount=3, maxBytes=40 * 1024 * 1024)
+    file_handler.setLevel(logging.DEBUG)
+    file_handler.setFormatter(CustomFormatter(no_ansi=True))
+
+    # console handler
+    console_handler = CustomHandler()
+    console_handler.setFormatter(CustomFormatter())
+
+    logger.handlers.clear()
+    logger.addHandler(file_handler)
+    logger.addHandler(console_handler)
+    logger.info("Logger initialized!")
+
+    return logger
+
+def log_exception(exc_type, exc_value, exc_traceback):
+    """Log uncaught exceptions."""
+    logger = logging.getLogger()
+    if not issubclass(exc_type, KeyboardInterrupt):
+        logger.error("Uncaught exception", exc_info=(exc_type, exc_value, exc_traceback))
+
+# Configure global exception handler to use the logger
+sys.excepthook = log_exception

--- a/bot/log.py
+++ b/bot/log.py
@@ -79,7 +79,7 @@ def setup() -> logging.RootLogger:
     logger = logging.getLogger()
 
     # Disable debug messages on these dumb libraries!
-    if '-discord-debug' not in sys.argv:
+    if '-discord-debug' not in sys.argv: # Run festivalinfobot.py with -discord-debug to enable discord.py DEBUG level logging 
         logging.getLogger('discord').setLevel(logging.INFO)
     logging.getLogger('urllib3').setLevel(logging.INFO)
     logging.getLogger('matplotlib').setLevel(logging.INFO)

--- a/bot/midi.py
+++ b/bot/midi.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import subprocess
 
@@ -20,27 +21,27 @@ class MidiArchiveTools:
 
         local_path = os.path.join(constants.LOCAL_MIDI_FOLDER, local_filename)
         if os.path.exists(local_path):
-            print(f"File {local_path} already exists, using local copy.")
+            logging.info(f"File {local_path} already exists, using local copy.")
             return local_path
 
         try:
             # Attempt to download the MIDI file
-            print(f'[GET] {midi_url}')
+            logging.debug(f'[GET] {midi_url}')
             response = requests.get(midi_url, timeout=10)  # Add timeout to avoid hanging
             response.raise_for_status()
 
             # Write the file to the local path
             with open(local_path, 'wb') as f:
                 f.write(response.content)
-            print(f"Downloaded and saved {local_filename}")
+            logging.info(f"Downloaded and saved {local_filename}")
             return local_path
         except requests.exceptions.RequestException as e:
             # Catch network-related issues and print a helpful error message
-            print(f"Failed to download {midi_url}: {e}")
+            logging.error(f"Failed to download {midi_url}", exc_info=e)
             return None
         except Exception as e:
             # Catch any other exceptions that could occur and log them
-            print(f"Unexpected error occurred while downloading {midi_url}: {e}")
+            logging.error(f"Unexpected error occurred while downloading {midi_url}", exc_info=e)
             return None
         
     def decrypt_dat_file(self, dat_url_or_path, output_file):
@@ -50,16 +51,16 @@ class MidiArchiveTools:
                 #print(f"Using local file: {dat_url_or_path}")
                 dat_file_path = dat_url_or_path
             else:
-                print(f"Downloading file from: {dat_url_or_path}")
+                logging.info(f"Downloading file from: {dat_url_or_path}")
                 dat_file_path = os.path.join(constants.TEMP_FOLDER, output_file)
                 # Download the .dat file
-                print(f'[GET] {dat_url_or_path}')
+                logging.debug(f'[GET] {dat_url_or_path}')
                 response = requests.get(dat_url_or_path)
                 if response.status_code == 200:
                     with open(dat_file_path, "wb") as file:
                         file.write(response.content)
                 else:
-                    print(f"Failed to download .dat file from {dat_url_or_path}")
+                    logging.error(f"Failed to download .dat file from {dat_url_or_path}, response code was {response.status_code}")
                     return None
 
             # Decrypt the .dat file to .mid
@@ -67,10 +68,10 @@ class MidiArchiveTools:
             
             # Check if the decrypted file already exists
             if not os.path.exists(decrypted_midi_path):
-                print(f"Decrypting {dat_file_path} to {decrypted_midi_path}...")
+                logging.info(f"Decrypting {dat_file_path} to {decrypted_midi_path}...")
                 result = subprocess.run(['python', 'fnf-midcrypt.py', '-d', dat_file_path], capture_output=True, text=True)
                 if result.returncode != 0:
-                    print(f"Decryption failed: {result.stderr}")
+                    logging.error(f"Decryption failed: {result.stderr}")
                     return decrypted_midi_path
             else:
                 #print(f"Decrypted MIDI file already exists: {decrypted_midi_path}")
@@ -79,13 +80,13 @@ class MidiArchiveTools:
             return decrypted_midi_path
 
         except Exception as e:
-            print(f"Error decrypting .dat file: {e}")
+            logging.error(f"Error decrypting .dat file", exc_info=e)
             return None
         
     # Helper function to modify the MIDI file for Pro Lead and Pro Bass and Pro Drum
     def modify_midi_file(self, midi_file: str, instrument: constants.Instrument, session_hash: str, shortname: str) -> str:
         try:
-            print(f"Loading MIDI file: {midi_file}")
+            logging.info(f"Loading MIDI file: {midi_file}")
             mid = mido.MidiFile(midi_file)
             track_names_to_delete = []
             track_names_to_rename = {}
@@ -95,8 +96,8 @@ class MidiArchiveTools:
             track_names_to_rename[instrument.midi] = instrument.replace
 
             # Logging track modification intent
-            print(f"Track names to delete: {track_names_to_delete}")
-            print(f"Track names to rename: {track_names_to_rename}")
+            logging.info(f"Track names to delete: {track_names_to_delete}")
+            logging.info(f"Track names to rename: {track_names_to_rename}")
 
             # Modify the tracks
             new_tracks = []
@@ -104,12 +105,12 @@ class MidiArchiveTools:
                 modified_track = mido.MidiTrack()  # Create a new track object
                 for msg in track:
                     if msg.type == 'track_name':
-                        print(f"Processing track: {msg.name}")
+                        logging.info(f"Processing track: {msg.name}")
                         if msg.name in track_names_to_delete:
-                            print(f"Deleting track: {msg.name}")
+                            logging.info(f"Deleting track: {msg.name}")
                             continue  # Skip tracks we want to delete
                         elif msg.name in track_names_to_rename:
-                            print(f"Renaming track {msg.name} to {track_names_to_rename[msg.name]}")
+                            logging.info(f"Renaming track {msg.name} to {track_names_to_rename[msg.name]}")
                             msg.name = track_names_to_rename[msg.name]  # Rename the track
                     modified_track.append(msg)  # Append the message to the new track
                 new_tracks.append(modified_track)
@@ -123,11 +124,11 @@ class MidiArchiveTools:
             modified_midi_file_name = f"{shortname}_{session_hash}.mid"  # Add session hash to the file name
             modified_midi_file = os.path.join(output_folder, modified_midi_file_name)  # Save in 'out' folder
 
-            print(f"Saving modified MIDI to: {modified_midi_file}")
+            logging.info(f"Saving modified MIDI to: {modified_midi_file}")
             mid.save(modified_midi_file)
-            print(f"Modified MIDI saved successfully.")
+            logging.info(f"Modified MIDI saved successfully.")
             return modified_midi_file
 
         except Exception as e:
-            print(f"Error modifying MIDI for {instrument}: {e}")
+            logging.error(f"Error modifying MIDI for {instrument}", exc_info=e)
             return None

--- a/bot/status.py
+++ b/bot/status.py
@@ -5,6 +5,8 @@ import logging
 
 import requests
 
+from bot import helpers
+
 class StatusHandler():
     def __init__(self) -> None:
         pass
@@ -77,9 +79,10 @@ class StatusHandler():
             embed.add_field(name="Rating", value=rating)
             embed.set_image(url=island_data['squareImgSrc'])
 
-            embed.add_field(name="Island Details", value=f"[Click here to view more details](https://fortnite.com{island_data['islandUrl']})", inline=False)
+            view = helpers.OneButtonSimpleView(on_press=None, user_id=interaction.user.id, label="View More", link=f"https://fortnite.com{island_data['islandUrl']}", emoji=None)
+            view.message = await interaction.original_response()
 
-            await interaction.edit_original_response(embed=embed)
+            await interaction.edit_original_response(embed=embed, view=view)
         else:
             embed = discord.Embed(title=search_for, description="Island not found", color=0x8927A1)
             await interaction.edit_original_response(embed=embed)

--- a/bot/status.py
+++ b/bot/status.py
@@ -1,0 +1,85 @@
+from datetime import datetime as dt
+import datetime
+import discord
+import logging
+
+import requests
+
+class StatusHandler():
+    def __init__(self) -> None:
+        pass
+
+    async def handle_fortnitestatus_interaction(self, interaction: discord.Interaction):
+        lightswitch_url = 'https://raw.githubusercontent.com/FNLookup/data/main/nitestats/light_switch.json'
+        timestamp_url = 'https://raw.githubusercontent.com/FNLookup/data/refs/heads/main/nitestats/timestamp.json'
+        logging.debug(f'[GET] {lightswitch_url}')
+        logging.debug(f'[GET] {timestamp_url}')
+
+        await interaction.response.defer()
+
+        response = requests.get(lightswitch_url)
+        data = response.json()[0]
+
+        timestamp = requests.get(timestamp_url).json()['timestamp']
+
+        is_fortnite_online = data['status'] == 'UP'
+        status_unknown = False
+        if data['status'] not in ['UP', 'DOWN']:
+            is_fortnite_online = True
+            status_unknown = True
+
+        colour = 0x25be56 # green
+        if not is_fortnite_online:
+            colour = 0xbe2625 # red
+        if status_unknown:
+            colour = 0xff7a08 # orange (perhaps)
+
+        embed = discord.Embed(title="Fortnite Status", description=data['message'], colour=colour)
+        date = dt.fromtimestamp(float(timestamp), datetime.timezone.utc).strftime('%B %d, %Y at %I:%M:%S %p UTC')
+        embed.set_footer(text=f"Last Updated: {date}")
+
+        await interaction.edit_original_response(embed=embed)
+
+    async def handle_gamemode_interaction(self, interaction: discord.Interaction, search_for:str = 'Festival Main Stage'):
+        manifest_url = 'https://raw.githubusercontent.com/FNLookup/data/main/page/context_en-US.json'
+        logging.debug(f'[GET] {manifest_url}')
+
+        await interaction.response.defer()
+
+        response = requests.get(manifest_url)
+        island_groups = response.json()['state']['loaderData']['routes/_index']['islands'] # hopefully this doesnt break
+        
+        island_data = None
+
+        for group in island_groups:
+            for island in group['islands']:
+                if island.get('title', '') == search_for:
+                    island_data = island
+
+        if island_data:
+            desc = "Play in a band with friends or perform solo on stage with hit music by your favorite artists in Fortnite Festival! On the Main Stage, play a featured rotation of Jam Tracks. Compete against friends for the best performance or team up to climb the leaderboards. The festival is just beginning with more Jam Tracks, Music Icons, concerts, and stages coming soon. Take your stage in Fortnite Festival!"
+            if search_for == 'Festival Battle Stage':
+                desc = "Let the battle begin! Compete in a musical free-for-all where only one player will emerge victorious. Perform a 4-song setlist of hit music, while taking and launching attacks. Seize the stage!"
+            elif search_for == 'Festival Jam Stage':
+                desc = "Explore the Jam Stage festival grounds to find friends and stages where you can mix hit music using the Jam Tracks in your locker. The festival is just beginning with more Jam Tracks, Music Icons, concerts, and stages coming soon. Take your stage in Fortnite Festival!"
+
+            embed = discord.Embed(title=island_data['title'], description=desc, color=0x8927A1)
+            if island_data.get('label', False):
+                embed.add_field(name="Label", value=island_data['label'])
+            embed.add_field(name="Players", value=island_data['ccu'])
+
+            rating = island_data['ageRatingTextAbbr']
+            if island_data['ageRatingTextAbbr'] == 'T':
+                rating = 'Teen'
+            if island_data['ageRatingTextAbbr'] == 'E10+':
+                rating = 'Everyone 10+'
+
+            embed.add_field(name="Rating", value=rating)
+            embed.set_image(url=island_data['squareImgSrc'])
+
+            embed.add_field(name="Island Details", value=f"[Click here to view more details](https://fortnite.com{island_data['islandUrl']})", inline=False)
+
+            await interaction.edit_original_response(embed=embed)
+        else:
+            embed = discord.Embed(title=search_for, description="Island not found", color=0x8927A1)
+            await interaction.edit_original_response(embed=embed)

--- a/bot/tracks.py
+++ b/bot/tracks.py
@@ -180,9 +180,9 @@ class SearchCommandHandler:
                 if track['track'].get('isrc', None):
                     spotify = self.jam_track_handler.get_spotify_link(track['track']['isrc'], str(interaction.user.id))
 
-                    view = helpers.OneButtonSimpleView(on_press=None, user_id=interaction.user.id, label="Listen in Spotify", emoji=None, link=spotify, restrict_only_to_creator=False)
-                    view.message = message
-
-                    await message.edit(embed=embed, view=view)
+                    if spotify:
+                        view = helpers.OneButtonSimpleView(on_press=None, user_id=interaction.user.id, label="Listen in Spotify", emoji=None, link=spotify, restrict_only_to_creator=False)
+                        view.message = message
+                        await message.edit(embed=embed, view=view)
         except Exception as e:
             logging.error('Error attempting to add view | Spotify link to message', exc_info=e)

--- a/bot/tracks.py
+++ b/bot/tracks.py
@@ -59,7 +59,7 @@ class JamTrackHandler:
         logging.debug(f'[GET] {url}')
 
         rand_div = random.randint(0, len(session))
-        permission = session[:rand_div] + '+8*' + session[:rand_div]
+        permission = session[:rand_div] + '+8*' + session[rand_div:]
         logging.debug(f'[HEADER] ftperms = {permission}')
 
         link = requests.get(url, headers={'ftperms': permission})

--- a/compare_midi.py
+++ b/compare_midi.py
@@ -456,6 +456,8 @@ def visualize_midi_changes(differences, text_differences, note_name_map, track_n
     ax.grid(True, linestyle='--', alpha=0.7)
 
     track_name = track_name.replace(' ', '_')
+
+    plt.tight_layout()
     
     # Save the plot to the output folder with session ID in the file name
     image_path = os.path.join(output_folder, f"{track_name}_changes_{session_id}.png")

--- a/festivalinfobot.py
+++ b/festivalinfobot.py
@@ -294,15 +294,15 @@ class FestivalInfoBot(commands.Bot):
             await self.lightswitch_handler.handle_fortnitestatus_interaction(interaction=interaction)
 
         @self.tree.command(name="mainstage", description="View information about Festival Main Stage.")
-        async def fortnitestatus_command(interaction: discord.Interaction):
+        async def mainstage_command(interaction: discord.Interaction):
             await self.lightswitch_handler.handle_gamemode_interaction(interaction=interaction)
 
         @self.tree.command(name="battlestage", description="View information about Festival Battle Stage.")
-        async def fortnitestatus_command(interaction: discord.Interaction):
+        async def battlestage_command(interaction: discord.Interaction):
             await self.lightswitch_handler.handle_gamemode_interaction(interaction=interaction, search_for="Festival Battle Stage")
 
         @self.tree.command(name="jamstage", description="View information about Festival Jam Stage.") 
-        async def fortnitestatus_command(interaction: discord.Interaction):
+        async def jamstage_command(interaction: discord.Interaction):
             await self.lightswitch_handler.handle_gamemode_interaction(interaction=interaction, search_for="Festival Jam Stage")
 
         @self.tree.command(name="stats", description="Displays Festival Tracker stats")

--- a/festivalinfobot.py
+++ b/festivalinfobot.py
@@ -1,6 +1,6 @@
-import asyncio
+import difflib
+import logging
 from datetime import datetime
-import json
 import time
 from discord.ext import commands, tasks
 import discord
@@ -8,29 +8,29 @@ from discord import app_commands
 from configparser import ConfigParser
 
 from bot import config, constants, embeds
+from bot.log import setup as setup_log
 from bot.admin import AdminCog, TestCog
 from bot.config import Config
+from bot.graph import GraphCommandsHandler
 from bot.history import HistoryHandler, LoopCheckHandler
 from bot.leaderboard import LeaderboardCommandHandler
 from bot.path import PathCommandHandler
+from bot.status import StatusHandler
 from bot.tracks import SearchCommandHandler, JamTrackHandler
 from bot.helpers import DailyCommandHandler, ShopCommandHandler, TracklistHandler, GamblingHandler
 
 class FestivalInfoBot(commands.Bot):
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-
     async def on_ready(self):
         # Setup all the subscription commands
-        print("Setting up admin commands...")
+        logging.debug("Setting up admin commands...")
         # Apparently this works, dont know why but
         # it is possible to await this function here
         await self.setup_admin_commands()
         
-        print(f'Logged in as {self.user.name}')
+        logging.info(f'Logged in as {self.user.name}')
 
-        print("Bot now active on:")
-        print("No.".ljust(5), "Name".ljust(30), "ID".ljust(20), "Join Date")
+        logging.info("Bot going active on:")
+        logging.info(' '.join(["No.".ljust(5), "Name".ljust(30), "ID".ljust(20), "Join Date"]))
         
         # Sort guilds by the bot's join date
         sorted_guilds = sorted(
@@ -44,17 +44,18 @@ class FestivalInfoBot(commands.Bot):
                 guild.me.joined_at.strftime("%Y-%m-%d %H:%M:%S") 
                 if guild.me.joined_at else "Unknown"
             )
-            print(
-                str(index).ljust(5),
-                guild.name.ljust(30), 
-                str(guild.id).ljust(20), 
-                join_date
+            logging.info(
+                ' '.join([str(index).ljust(5),
+                    guild.name.ljust(30), 
+                    str(guild.id).ljust(20), 
+                    join_date
+                ])
             )
 
-        print("Syncing slash command tree...")
+        logging.debug("Syncing slash command tree...")
         await self.tree.sync()
 
-        print("Setting activity...")
+        logging.debug("Creating activity...")
         # Set up the rich presence activity
         activity = discord.Activity(
             type=discord.ActivityType.playing, 
@@ -62,6 +63,7 @@ class FestivalInfoBot(commands.Bot):
         )
 
         # Apply the activity
+        logging.debug("Applying activity...")
         await self.change_presence(activity=activity, status=discord.Status.online)
 
         @tasks.loop(minutes=self.CHECK_FOR_SONGS_INTERVAL)
@@ -70,12 +72,16 @@ class FestivalInfoBot(commands.Bot):
         if self.CHECK_FOR_NEW_SONGS:
             check_for_new_songs.start()
 
-        print("Bot is now running!")
+        logging.info("Bot is now running!")
 
     def __init__(self):
         # Load configuration from config.ini
+        setup_log()
+
         config = ConfigParser()
         config.read('config.ini')
+
+        self.config : Config = None
 
         def reload_config():
            self.config = Config(config_file="channels.json", reload_callback=reload_config) 
@@ -101,7 +107,7 @@ class FestivalInfoBot(commands.Bot):
 
         super().__init__(
             # Prefix must be set, but no commands are in the 'text command list' so it wont do anything
-            command_prefix="!",
+            command_prefix="ft!",
             help_command=None,
             intents=intents
         )
@@ -115,13 +121,26 @@ class FestivalInfoBot(commands.Bot):
         self.history_handler = HistoryHandler()
         self.check_handler = LoopCheckHandler(self)
         self.gambling_handler = GamblingHandler()
+        self.graph_handler = GraphCommandsHandler()
+        self.lightswitch_handler = StatusHandler()
 
         self.setup_commands()
         self.setup_subscribe_commands()
 
-        self.run(DISCORD_TOKEN)
+        self.run(DISCORD_TOKEN, log_handler=None)
 
     def setup_commands(self):
+
+        # This command is secret; it can be used to inmediately check if Festival Tracker
+        # is online without having to go through application commands
+        # Invokable by "ft!online"
+        @self.command(name="online")
+        async def checkonline_command(ctx):
+            if ctx.message.channel.permissions_for(ctx.message.channel.guild.me).add_reactions:
+                await ctx.message.add_reaction("✅")
+            else:
+                await ctx.send(f"{ctx.message.channel.guild.me.display_name} is online.")
+
         @self.tree.command(name="search", description="Search a song.")
         @app_commands.describe(query = "A search query: an artist, song name, or shortname.")
         async def search_command(interaction: discord.Interaction, query:str):
@@ -181,9 +200,14 @@ class FestivalInfoBot(commands.Bot):
         @self.tree.command(name="path", description="Generates an Overdrive path for a song using CHOpt.")
         @app_commands.describe(song = "A search query: an artist, song name, or shortname.")
         @app_commands.describe(instrument = "The instrument to view the path of.")
-        @app_commands.describe(squeeze_percent = "Squeeze Percent value")
-        @app_commands.describe(difficulty = "The difficulty to view the path for")
-        async def path_command(interaction: discord.Interaction, song:str, instrument:constants.Instruments, squeeze_percent: discord.app_commands.Range[int, 0, 100] = 20, difficulty:constants.Difficulties = constants.Difficulties.Expert):
+        @app_commands.describe(difficulty = "The difficulty to view the path for.")
+        @app_commands.describe(squeeze_percent = "Change CHOpt's Squeeze parameter.")
+        @app_commands.describe(lefty_flip = "Enable CHOpt to render in Lefty Flip mode.")
+        @app_commands.describe(act_opacity = "Set the opacity of activations in images.")
+        @app_commands.describe(no_bpms = "If set to True, CHOpt will not draw BPMs.")
+        @app_commands.describe(no_solos = "If set to True, CHOpt will not draw Solo Sections.")
+        @app_commands.describe(no_time_signatures = "If set to True, CHOpt will not draw Time Signatures.")
+        async def path_command(interaction: discord.Interaction, song:str, instrument:constants.Instruments, difficulty:constants.Difficulties = constants.Difficulties.Expert, squeeze_percent: discord.app_commands.Range[int, 0, 100] = 20, lefty_flip : bool = False, act_opacity: discord.app_commands.Range[int, 0, 100] = None, no_bpms: bool = False, no_solos: bool = False, no_time_signatures: bool = False):
             if not self.PATHING_ALLOWED or not self.DECRYPTION_ALLOWED:
                 await interaction.response.send_message(content="This command is not enabled in this bot.", ephemeral=True)
                 return
@@ -193,7 +217,14 @@ class FestivalInfoBot(commands.Bot):
                 song=song,
                 instrument=instrument,
                 squeeze_percent=squeeze_percent,
-                difficulty=difficulty
+                difficulty=difficulty,
+                extra_args=[
+                    lefty_flip,
+                    act_opacity,
+                    no_bpms,
+                    no_solos,
+                    no_time_signatures
+                ]
             )
 
         @self.tree.command(name="history", description="View the history of a Jam Track.")
@@ -202,13 +233,77 @@ class FestivalInfoBot(commands.Bot):
             if not self.CHART_COMPARING_ALLOWED or not self.DECRYPTION_ALLOWED:
                 await interaction.response.send_message(content="This command is not enabled in this bot.", ephemeral=True)
                 return
+            
+            if not interaction.channel.permissions_for(interaction.guild.me).view_channel:
+                await interaction.response.send_message(content="You must be in a channel where I can send messages to use this command.", ephemeral=True)
+                return
     
             await self.history_handler.handle_interaction(interaction=interaction, song=song)
 
         @self.tree.command(name="metahistory", description="View the metadata history of a Jam Track.")
         @app_commands.describe(song = "A search query: an artist, song name, or shortname.")
         async def metahistory_command(interaction: discord.Interaction, song:str):
+            if not interaction.channel.permissions_for(interaction.guild.me).view_channel:
+                await interaction.response.send_message(content="You must be in a channel where I can send messages to use this command.", ephemeral=True)
+                return
+
             await self.history_handler.handle_metahistory_interaction(interaction=interaction, song=song)
+
+        @self.tree.command(name="graph_note_counts", description="Graph the note counts for a specific song.")
+        @app_commands.describe(song = "A search query: an artist, song name, or shortname.")
+        async def graph_note_counts_command(interaction: discord.Interaction, song:str):
+            if not self.DECRYPTION_ALLOWED:
+                await interaction.response.send_message(content="This command is not enabled in this bot.", ephemeral=True)
+                return
+
+            await self.graph_handler.handle_pdi_interaction(interaction=interaction, song=song)
+
+        @self.tree.command(name="graph_lifts", description="Graph the lift counts for a specific song.")
+        @app_commands.describe(song = "A search query: an artist, song name, or shortname.")
+        async def graph_note_counts_command(interaction: discord.Interaction, song:str):
+            if not self.DECRYPTION_ALLOWED:
+                await interaction.response.send_message(content="This command is not enabled in this bot.", ephemeral=True)
+                return
+            
+            await self.graph_handler.handle_lift_interaction(interaction=interaction, song=song)
+
+        @self.tree.command(name="graph_nps", description="Graph the NPS (Notes per second) for a specific song, instrument, and difficulty.")
+        @app_commands.describe(song = "A search query: an artist, song name, or shortname.")
+        @app_commands.describe(instrument = "The instrument to view the NPS of.")
+        @app_commands.describe(difficulty = "The difficulty to view the NPS for.")
+        async def graph_nps_command(interaction: discord.Interaction, song:str, instrument : constants.Instruments, difficulty : constants.Difficulties = constants.Difficulties.Expert):
+            if not self.DECRYPTION_ALLOWED:
+                await interaction.response.send_message(content="This command is not enabled in this bot.", ephemeral=True)
+                return
+            
+            await self.graph_handler.handle_nps_interaction(interaction=interaction, song=song, instrument=instrument, difficulty=difficulty)
+
+        @self.tree.command(name="graph_lanes", description="Graph the number of notes for each lane in a specific song, instrument, and difficulty.")
+        @app_commands.describe(song = "A search query: an artist, song name, or shortname.")
+        @app_commands.describe(instrument = "The instrument to view the #notes of.")
+        @app_commands.describe(difficulty = "The difficulty to view the #notes for.")
+        async def graph_lanes_command(interaction: discord.Interaction, song:str, instrument : constants.Instruments, difficulty : constants.Difficulties = constants.Difficulties.Expert):
+            if not self.DECRYPTION_ALLOWED:
+                await interaction.response.send_message(content="This command is not enabled in this bot.", ephemeral=True)
+                return
+            
+            await self.graph_handler.handle_lanes_interaction(interaction=interaction, song=song, instrument=instrument, difficulty=difficulty)
+
+        @self.tree.command(name="fortnitestatus", description="See if Fortnite is currently online or offline.")
+        async def fortnitestatus_command(interaction: discord.Interaction):
+            await self.lightswitch_handler.handle_fortnitestatus_interaction(interaction=interaction)
+
+        @self.tree.command(name="mainstage", description="View information about Festival Main Stage.")
+        async def fortnitestatus_command(interaction: discord.Interaction):
+            await self.lightswitch_handler.handle_gamemode_interaction(interaction=interaction)
+
+        @self.tree.command(name="battlestage", description="View information about Festival Battle Stage.")
+        async def fortnitestatus_command(interaction: discord.Interaction):
+            await self.lightswitch_handler.handle_gamemode_interaction(interaction=interaction, search_for="Festival Battle Stage")
+
+        @self.tree.command(name="jamstage", description="View information about Festival Jam Stage.") 
+        async def fortnitestatus_command(interaction: discord.Interaction):
+            await self.lightswitch_handler.handle_gamemode_interaction(interaction=interaction, search_for="Festival Jam Stage")
 
         @self.tree.command(name="stats", description="Displays Festival Tracker stats")
         async def bot_stats(interaction: discord.Interaction):
@@ -262,7 +357,8 @@ class FestivalInfoBot(commands.Bot):
                 # Add command to embed
                 if isinstance(_command, discord.app_commands.commands.Group):
                     for group_command in _command.commands:
-                        if group_command.guild_only and isinstance(interaction.channel, discord.DMChannel):
+                        # Only the group can have the guild only attribute
+                        if _command.guild_only and isinstance(interaction.channel, discord.DMChannel):
                             continue
                         commands.append({
                             "name":f"`/{_command.name} {group_command.name}`",
@@ -283,7 +379,7 @@ class FestivalInfoBot(commands.Bot):
                         if isinstance(found_command, discord.app_commands.commands.Group):
                             found_command = found_command.get_command(command.split(' ')[1])
                     except Exception as e:
-                        print(e)
+                        logging.error(exc_info=e)
                         await interaction.response.send_message(content=f"No command found with the name \"{command}\"", ephemeral=True)
                         return
                     
@@ -313,7 +409,14 @@ class FestivalInfoBot(commands.Bot):
 
                     await interaction.response.send_message(embed=embed)
                 else:
-                    await interaction.response.send_message(content=f"No command found with the name \"{command}\"", ephemeral=True)
+                    command_list = [str(command.qualified_name) for command in self.tree.get_commands()]
+                    close_match = difflib.get_close_matches(command, command_list, n=1, cutoff=0.7)
+                    tip = ""
+                    if close_match:
+                        if len(close_match) > 0:
+                            tip = f"\n*Did you mean: `{close_match[0]}`?*"
+
+                    await interaction.response.send_message(content=f"No command found with the name \"{command}\"{tip}", ephemeral=True)
                     return
             else:
                 embeds = []
@@ -357,7 +460,7 @@ class FestivalInfoBot(commands.Bot):
             else:
                 for i, _user in enumerate(user_list):
                     if i > 0:
-                        print(f'Found another user for {interaction.user.id}?\nUser no. {i}')
+                        logging.warning(f'Found another user for {interaction.user.id}? User no. {i}')
 
                     subscribed_user_events = self.config.users[self.config.users.index(_user)].events
                     if len(subscribed_user_events) == len(config.JamTrackEvent.get_all_events()):
@@ -385,7 +488,7 @@ class FestivalInfoBot(commands.Bot):
             else:
                 for i, _user in enumerate(user_list):
                     if i > 0:
-                        print(f'Found another user for {interaction.user.id}?\nUser no. {i}')
+                        logging.warning(f'Found another user for {interaction.user.id}? User no. {i}')
                     try:
                         self.config.users.remove(_user)
                     except ValueError as e:
@@ -411,7 +514,7 @@ class FestivalInfoBot(commands.Bot):
             else:
                 for i, _user in enumerate(user_list):
                     if i > 0:
-                        print(f'Found another user for {interaction.user.id}?\nUser no. {i}')
+                        logging.warning(f'Found another user for {interaction.user.id}? User no. {i}')
 
                     subscribed_events = self.config.users[self.config.users.index(_user)].events
                     if chosen_event in subscribed_events:
@@ -440,7 +543,7 @@ class FestivalInfoBot(commands.Bot):
             else:
                 for i, _user in enumerate(user_list):
                     if i > 0:
-                        print(f'Found another user for {interaction.user.id}?\nUser no. {i}')
+                        logging.warning(f'Found another user for {interaction.user.id}? User no. {i}')
 
                     subscribed_events = self.config.users[self.config.users.index(_user)].events
 

--- a/graphs.py
+++ b/graphs.py
@@ -1,0 +1,189 @@
+import os
+import bot.constants as const
+import mido
+from midi_to_milliseconds import midi_to_object
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+def generate_nps_chart(midi_path : str, path : str, inst : const.Instrument, diff : const.Difficulty, song_name, song_artist):
+    _notes = midi_to_object(midi_file_path=midi_path)
+
+    instrument_idx = 0
+    for i, track in enumerate(_notes['tracks']):
+        instrument_idx = i
+        if track['name'] == inst.midi:
+            break
+
+    notes = _notes['tracks'][instrument_idx]['notes']
+    filtered_notes_seconds = [(note["start_time"] / 1000) for note in notes if diff.pitch_ranges[0] <= note["note"] <= diff.pitch_ranges[1]]
+
+    # Group by seconds (integer part of the start time in seconds)
+    grouped_by_second = {}
+    for note_time in filtered_notes_seconds:
+        second = int(note_time)  # Group by whole second
+        if second in grouped_by_second:
+            grouped_by_second[second] += 1
+        else:
+            grouped_by_second[second] = 1
+
+    # Prepare data for plotting
+    seconds = sorted(grouped_by_second.keys())
+    notes_per_second = [grouped_by_second[second] for second in seconds]
+
+    max_nps = max(notes_per_second)
+    max_nps_second = seconds[notes_per_second.index(max_nps)]
+
+    # Calculate Exponential Moving Average (EMA)
+    window_size = 10  # Can adjust as needed
+    df = pd.DataFrame({'nps': notes_per_second}, index=seconds)
+    ema = df['nps'].ewm(span=window_size, adjust=False).mean()  # EMA calculation
+
+    # Plotting
+    plt.figure(figsize=(10, 4))
+
+    # Plot the original notes per second
+    plt.plot(seconds, notes_per_second, color='black', linestyle='-', linewidth=1, label='Notes per second')
+
+    # Plot the EMA
+    plt.plot(ema.index, ema.values, color='purple', linestyle='--', linewidth=1, label='EMA (Average)')
+
+    plt.text(max_nps_second, max_nps, f'{max_nps}', color='blue', fontsize=10, ha='center', va='bottom')
+
+    # Setting labels
+    plt.xlabel('Time (seconds)')
+    plt.ylabel('Notes per second')
+    plt.title(f'{song_name} - {song_artist}: NPS ({diff.english} {inst.english})')
+
+    # Reduce the frequency of the x-ticks, e.g., every 10 seconds
+    plt.xticks(np.arange(min(seconds), max(seconds)+1, 10))
+
+    # Rotate x-axis labels for better readability
+    plt.xticks(rotation=90)
+
+    # Only keep horizontal grid lines
+    plt.grid(axis='y')
+
+    # Show legend
+    plt.legend()
+
+    plt.tight_layout()  # Adjust layout to fit rotated labels
+    plt.savefig(os.path.join(const.TEMP_FOLDER, path))
+
+    plt.close()
+
+def generate_lanes_chart(midi_path : str, spath : str, inst : const.Instrument, diff : const.Difficulty, song_name, song_artist):
+    labels = ['Green', 'Red', 'Yellow', 'Blue', 'Orange']
+    notes = [0, 0, 0, 0, 0]
+
+    mid = mido.MidiFile(midi_path)
+    for track in mid.tracks:
+        if track.name == inst.midi:
+            for msg in track:
+                if msg.type == 'note_on':
+                    start = diff.pitch_ranges[0]
+                    end = diff.pitch_ranges[1]
+
+                    if msg.note >= start and msg.note <= end:
+                        lane = msg.note - start
+                        notes[lane] += 1
+
+    # Create the bar plot
+    plt.bar(labels, notes, color=['green', 'red', 'yellow', 'blue', 'orange'])
+
+    # Add the exact numbers above each bar
+    for i, value in enumerate(notes):
+        plt.text(i, value + 3, str(value), ha='center')
+
+    # Add labels and title
+    plt.xlabel('Lanes')
+    plt.ylabel('Number of Notes')
+    plt.title(f'{song_artist} - {song_name}: Notes per lane ({diff.english} {inst.english})')
+
+    # Display the plot
+    plt.savefig(os.path.join(const.TEMP_FOLDER, spath))
+
+    plt.close()
+
+def generate_no_notes_pdi_chart(midi_path : str, path : str, song_name, song_artist, lifts : bool = False):
+    # Data for each instrument and difficulty level
+    labels = []
+    easy = []
+    medium = []
+    hard = []
+    expert = []
+    mid = mido.MidiFile(midi_path)
+    for instrument in const.Instruments.getall():
+        if lifts:
+            if instrument.plastic:
+                continue
+
+        labels.append(instrument.english)
+        for difficulty in const.Difficulties.getall():
+            total_notes = 0
+
+            for track in mid.tracks:
+                if track.name == instrument.midi:
+                    for msg in track:
+                        if msg.type == 'note_on':
+                            start = difficulty.pitch_ranges[0]
+                            end = difficulty.pitch_ranges[1]
+                            if lifts:
+                                start += 6
+                                end += 6
+
+                            if msg.note >= start and msg.note <= end:
+                                total_notes += 1
+
+            if difficulty.chopt == 'expert':
+                expert.append(total_notes)
+            elif difficulty.chopt == 'hard':
+                hard.append(total_notes)
+            elif difficulty.chopt == 'medium':
+                medium.append(total_notes)
+            elif difficulty.chopt == 'easy':
+                easy.append(total_notes)
+
+    # Number of groups and positions of bars
+    x = np.arange(len(labels))  # Label locations
+    width = 0.2  # Width of bars
+
+    # Create subplots
+    fig, ax = plt.subplots(figsize=(10, 6))
+
+    # Plot bars for each difficulty level
+    rects1 = ax.bar(x - 1.5*width, easy, width, label='Easy', color='orange')
+    rects2 = ax.bar(x - 0.5*width, medium, width, label='Medium', color='blue')
+    rects3 = ax.bar(x + 0.5*width, hard, width, label='Hard', color='green')
+    rects4 = ax.bar(x + 1.5*width, expert, width, label='Expert', color='purple')
+
+    # Add labels, title, and legend
+    ax.set_xlabel('Instrument')
+    ax.set_ylabel('Notes')
+    ax.set_title(f'{song_artist} - {song_name}: ' + ('Note counts' if not lifts else 'Lift counts'))
+    ax.set_xticks(x)
+    ax.set_xticklabels(labels)
+    ax.legend()
+
+    # Function to add numbers on top of each bar
+    def add_bar_labels(rects):
+        for rect in rects:
+            height = rect.get_height()
+            ax.text(
+                rect.get_x() + rect.get_width() / 2, height + 10,
+                f'{height}',  # Label text (height of the bar)
+                ha='center', va='bottom', color='black', rotation=90  # Position and color of text
+            )
+
+    # Add labels on top of each bar
+    add_bar_labels(rects1)
+    add_bar_labels(rects2)
+    add_bar_labels(rects3)
+    add_bar_labels(rects4)
+
+    # Display the graph
+    # plt.tight_layout()
+    plt.tight_layout()
+    plt.savefig(os.path.join(const.TEMP_FOLDER, path))
+
+    plt.close()

--- a/midi_to_milliseconds.py
+++ b/midi_to_milliseconds.py
@@ -1,0 +1,224 @@
+import logging
+import time
+import mido
+import json
+
+def get_length_in_beats(_bpm, ticks_since_last, ppqn):
+    #tempo  = mido.bpm2tempo(_bpm)
+
+    #bpm = mido.tempo2bpm(tempo)
+    bpm = _bpm
+
+    try:
+        beat_crochet = (60 / bpm)
+    except:
+        beat_crochet = 0
+    try:
+        length_in_beats_of_note = ticks_since_last / ppqn
+    except ZeroDivisionError:
+        length_in_beats_of_note = 0
+
+    return beat_crochet * length_in_beats_of_note
+
+def get_length_in_beats_tempo(tempo, ticks_since_last, ppqn):
+    try:
+        bpm = mido.tempo2bpm(tempo)
+    except Exception as e:
+        logging.error(f'Failed to make bpm, tempo is {tempo}', exc_info=e)
+        bpm = mido.tempo2bpm(500000)
+    return get_length_in_beats(bpm, ticks_since_last, ppqn)
+
+def get_tempo(time, tempo_times):
+    if not tempo_times:
+        return None  # Handle empty tempo_times list
+
+    # Check first tempo without decrementing i
+    if time <= tempo_times[0][0]:
+        return tempo_times[0]
+
+    for i, tempo_change in enumerate(tempo_times[1:], start=1):
+        check = i - 1
+        if tempo_times[check][0] <= time and tempo_change[0] >= time:
+            return tempo_times[check]
+    # Return last tempo if no match is found
+    return tempo_times[-1]
+
+def midi_to_object(midi_file_path):
+    mid = mido.MidiFile(midi_file_path)
+    
+    midi_data = {
+        'ticks_per_beat': mid.ticks_per_beat,
+        "tempo": [],
+        "time_signature": [],
+        'tracks': []
+    }
+
+    # Extract tempo and time signature events
+    tempo_times = []
+
+    # Process tempo changes first
+    for i, track in enumerate(mid.tracks):
+        absolute_time = 0
+        ticks_since_last_tempo = 0
+        previous_tempo_change_bpm = 0
+        tempo_change_times = 0
+
+        for msg in track:
+            absolute_time += msg.time
+            ticks_since_last_tempo += msg.time
+
+            if msg.type == "set_tempo":
+                # Tempo change times
+                tempo_change_times += get_length_in_beats(previous_tempo_change_bpm, ticks_since_last_tempo, mid.ticks_per_beat)
+
+                this_change_bpm = mido.tempo2bpm(msg.tempo)
+
+                midi_data["tempo"].append({
+                    # "time_since_last": msg.time,
+                    # "time_in_ticks": absolute_time,
+
+                    'time': tempo_change_times * 1000,
+                    "bpm": this_change_bpm,
+                    "tempo": msg.tempo
+                })
+
+                ticks_since_last_tempo = 0
+
+                prev = previous_tempo_change_bpm
+
+                previous_tempo_change_bpm = this_change_bpm
+
+                tempo_times.append([
+                    absolute_time, 
+                    this_change_bpm,
+                    tempo_change_times, 
+                    msg.tempo, 
+                    msg.time,
+                    prev,
+                    msg.time / mid.ticks_per_beat
+                ])
+
+            # if msg.type == "time_signature":
+            #     midi_data["time_signature"].append({
+            #         "time_since_last": msg.time,
+            #         "time_in_ticks": absolute_time,
+            #         "time": msg.time,
+            #         "numerator": msg.numerator,
+            #         "denominator": msg.denominator,
+            #         "click": msg.clocks_per_click,
+            #         "notesQ": msg.notated_32nd_notes_per_beat
+            #     })
+
+    for i, track in enumerate(mid.tracks):
+        track_data = {
+            "name": track.name,
+            "id": i,
+            "events": [],
+            "notes": []
+        }
+        active_notes = {}
+        absolute_time = 0
+        ticks_since_last_note_on = 0
+
+        for msg in track:
+            # On any event, the absolute time is still increasing.
+            absolute_time += msg.time
+            ticks_since_last_note_on += msg.time
+
+            if msg.type == 'text':
+                event_text = msg.text
+
+                # Tempo of note
+                tempo_event = get_tempo(absolute_time, tempo_times)
+                event_bpm = tempo_event[1]
+                absolute_time_of_event = tempo_event[0]
+                time_event_began = tempo_event[2]
+                ticks_for_recalc = absolute_time - absolute_time_of_event
+
+                current_event_time_s = time_event_began + get_length_in_beats(event_bpm, ticks_for_recalc, mid.ticks_per_beat)
+                track_data['events'].append({
+                    'time': current_event_time_s * 1000,
+                    'text': event_text
+                })
+
+            # If a note starts playing, write it down
+            if msg.type == 'note_on':
+                # Get the time in beats and increment the value
+
+                # Tempo of note
+                tempo_event = get_tempo(absolute_time, tempo_times)
+                event_bpm = tempo_event[1]
+
+                absolute_time_of_event = tempo_event[0]
+
+                time_event_began = tempo_event[2]
+                
+                ticks_for_recalc = absolute_time - absolute_time_of_event
+
+                # if ticks_for_recalc < 0: the note uses the previous bpm
+                #ticks_for_recalc = 0
+
+                current_note_time_s = time_event_began + get_length_in_beats(event_bpm, ticks_for_recalc, mid.ticks_per_beat)
+
+                # Use the current ticks_since_last_note_on, where we know at which tick began since the last note_on event
+                # Because the  time ticks_since_last_note_on is still increasing, note_off events will not affect this.
+                active_notes[msg.note] = [
+                    ticks_since_last_note_on,
+                    current_note_time_s,
+                    absolute_time,
+                ]
+
+                # Reset the ticks_since_last_note_on
+                ticks_since_last_note_on = 0
+
+                #time.sleep(0.1)
+                
+            elif msg.type == 'note_off':
+                # Get the note_on event
+                note_on_event = active_notes.pop(msg.note, None)
+
+                if note_on_event is not None:
+                    # Get the ticks since last note_on event at which this note began.
+                    note_ticks_since_last = note_on_event[0]
+
+                    # The time in beats this note began at
+                    note_time = note_on_event[1]
+
+                    # The absolute time the note began
+                    absolute_time_note_began = note_on_event[2]
+
+                    # When this note_off event starts, the duration will be the ticks since the last event
+                    # (last event being note_on)
+                    note_duration_ticks = absolute_time - absolute_time_note_began
+
+                    tempo_event = get_tempo(absolute_time, tempo_times)
+                    bpm_note = tempo_event[1]
+                    #print(f'Tempo at note_on: {bpm_note}')
+
+                    note_duration = get_length_in_beats(bpm_note, note_duration_ticks, mid.ticks_per_beat)
+
+                    # A hold note will be longer than a step.
+                    is_hold_note = note_duration_ticks > int(mid.ticks_per_beat / 4)
+
+                    #print(int(mid.ticks_per_beat / 4))
+                    
+                    note_data = {
+                        'note': msg.note,
+
+                        # Compat values
+                        'is_hold_note': is_hold_note,
+                        'start_time': note_time * 1000,
+                        'duration': note_duration * 1000
+                        
+                        # 'descriptor': dascription
+                    }
+
+                    track_data['notes'].append(note_data)
+                    
+        midi_data['tracks'].append(track_data)
+
+    return midi_data
+
+if __name__ == '__main__':
+    thing = midi_to_object('notes.mid')
+    open('notes_test.json', 'w').write(json.dumps(thing, indent=4))

--- a/sparks_tracks.py
+++ b/sparks_tracks.py
@@ -1,3 +1,4 @@
+import logging
 import requests
 import os
 from datetime import datetime
@@ -24,8 +25,9 @@ def get_commit_history():
 
     while True:
         params["page"] = page
-        print(f'[GET] {COMMITS_URL}')
-        response = requests.get(COMMITS_URL, headers=headers, params=params)
+        url = f'{COMMITS_URL}?' + '&'.join([f'{k}={v}' for k, v in params.items()])
+        logging.debug(f'[GET] {url}')
+        response = requests.get(url, headers=headers)
         response.raise_for_status()
         commits = response.json()
         
@@ -53,7 +55,7 @@ def download_file_at_commit(commit_sha, commit_timestamp):
         headers["Authorization"] = f"token {GITHUB_TOKEN}"
     
     raw_url = f"https://raw.githubusercontent.com/{REPO_OWNER}/{REPO_NAME}/{commit_sha}/{FILE_PATH}"
-    print(f'[GET] {raw_url}')
+    logging.debug(f'[GET] {raw_url}')
     response = requests.get(raw_url, headers=headers)
     response.raise_for_status()
 
@@ -70,7 +72,7 @@ def download_file_at_commit(commit_sha, commit_timestamp):
     with open(file_path, 'w', encoding='utf-8') as f:
         f.write(response.text)
 
-    print(f"Downloaded: {file_name}")
+    logging.debug(f"Downloaded: {file_name}")
 
 def already_downloaded(commit_timestamp):
     # Format the timestamp to match the filenames we have saved
@@ -83,7 +85,7 @@ def already_downloaded(commit_timestamp):
 
 def main():
     commit_history = get_commit_history()
-    print(f"Updating local repo of spark-tracks jsons")
+    logging.info(f"Updating local repo of spark-tracks jsons")
     
     for commit in commit_history:
         commit_sha = commit["sha"]


### PR DESCRIPTION
- incorporates the `logging` library to log events within the bot, also includes creating a log file if the space on the console runs out
- checks for "Add Reactions" permission where it needs to
- shrinks the size of the daily embeds
- adds more chopt arguments (optional arguments like: "lefty-flip", "act-opacity", "no-bpms", "no-solos", "no-time-sigs")
- adds a new test command: `/test logs` to test logging functionality
- adds a text command: "ft!online" to inmediately check if the bot is online
- fixes help command displaying guild only commands in dms
- adds close matches to help command

## significant commands
- `/graph_note_counts` generates a graph for the note counts of a song
![image](https://github.com/user-attachments/assets/d495c24c-0d87-44d6-9789-08334b777f78)
- `/graph_lifts` generates a graph for the lift counts of a song
- `/graph_nps` creates a graph of the nps of a song & instrument (& difficulty.)
![image](https://github.com/user-attachments/assets/fbbb7142-2d4d-478b-9df1-8c836066a1a3)
- `/graph_lanes` creates a graph of the notes in each lane of a song & instrument (& difficulty.)
![image](https://github.com/user-attachments/assets/56364112-8277-4c15-b6ad-15ae342e12c4)
- `/fortnitestatus` displays if fortnite is on downtime
- `/battlestage`, `/mainstage`, `/jamstage` displays information about each mode
![image](https://github.com/user-attachments/assets/a816c915-c325-40d5-bd31-69466d272098)

## notes
the `pandas` module is required on `graphs.py`.