### PR TITLE
Adding support to the bot to query for optimal songs to mix with based on Key/Mode or a specific song.

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -404,6 +404,22 @@ class AllTimeLBType:
     def __str__(self) -> str:
         return f"AllTimeLBType({self.english=}, {self.code=})".replace('self.', '')
 
+class KeyType:
+    def __init__(self, english:str = "A", code: str = 'A') -> None:
+        self.english = english
+        self.code = code
+
+    def __str__(self) -> str:
+        return f"KeyType({self.english=}, {self.code=})".replace('self.', '')
+        
+class ModeType:
+    def __init__(self, english:str = "Major", code: str = 'Major') -> None:
+        self.english = english
+        self.code = code
+
+    def __str__(self) -> str:
+        return f"ModeType({self.english=}, {self.code=})".replace('self.', '')
+
 class Instruments(enum.Enum):
     ProLead = Instrument(english="Pro Lead", lb_code="Solo_PeripheralGuitar", plastic=True, chopt="proguitar", midi="PLASTIC GUITAR")
     ProBass = Instrument(english="Pro Bass", lb_code="Solo_PeripheralBass", plastic=True, chopt="probass", midi="PLASTIC BASS")
@@ -449,6 +465,57 @@ class AllTimeLBTypes(enum.Enum):
     BandDuos = AllTimeLBType(english="Band Duos", code="Band_Duets", is_band=True)
     BandTrios = AllTimeLBType(english="Band Trios", code="Band_Trios", is_band=True)
     BandSquads = AllTimeLBType(english="Band Squads", code="Band_Quad", is_band=True)
+    
+class KeyTypes(enum.Enum):
+    A = KeyType(english="A", code="A")
+    ASharp = KeyType(english="A#", code="Bb")
+    Bb = KeyType(english="B♭", code="Bb")
+    B = KeyType(english="B", code="B")
+    C = KeyType(english="C", code="C")
+    CSharp = KeyType(english="C#", code="Db")
+    Db = KeyType(english="D♭", code="Db")
+    D = KeyType(english="D", code="D")
+    DSharp = KeyType(english="D#", code="Eb")
+    Eb = KeyType(english="E♭", code="Eb")
+    E = KeyType(english="E", code="E")
+    ESharp = KeyType(english="E#", code="Fb")
+    Fb = KeyType(english="F♭", code="Fb")
+    F = KeyType(english="F", code="F")
+    FSharp = KeyType(english="F#", code="Gb")
+    Gb = KeyType(english="G♭", code="Gb")
+    G = KeyType(english="G", code="G")
+    GSharp = KeyType(english="G#", code="Ab")
+    Ab = KeyType(english="A♭", code="Ab")
+
+    # The @classmethod decorator just works!
+    @classmethod
+    def getall(self) -> list[KeyType]:
+        return [self.A.value, 
+        self.ASharp.value, 
+        self.Bb.value, 
+        self.C.value, 
+        self.CSharp.value, 
+        self.Db.value, 
+        self.D.value, 
+        self.DSharp.value, 
+        self.Eb.value, 
+        self.E.value, 
+        self.ESharp.value, 
+        self.Fb.value, 
+        self.F.value, 
+        self.FSharp.value, 
+        self.Gb.value, 
+        self.G.value, 
+        self.GSharp.value, 
+        self.Ab.value]
+    
+class ModeTypes(enum.Enum):
+    Major = ModeType(english="Major", code="Major")
+    Minor = ModeType(english="Minor", code="Minor")
+
+    @classmethod
+    def getall(self) -> list[ModeType]:
+        return [self.Major.value, self.Minor.value]
 
 def get_jam_tracks():
     content_url = CONTENT_API

--- a/bot/mix.py
+++ b/bot/mix.py
@@ -1,0 +1,118 @@
+import discord
+from bot.tracks import JamTrackHandler, ResultsJamTracks
+from bot import constants
+import random
+
+class MixHandler():
+    def __init__(self) -> None:
+        self.jam_track_handler = JamTrackHandler()
+        pass
+    
+
+    async def handle_embed(self, interaction: discord.Interaction, matched_tracks:list, key:str, mode:str, songName: str = '', should_edit_response: bool = False):
+        embed_array = []
+        random.shuffle(matched_tracks) # Some uniqueness every time you execute, especially for longer lists
+
+        if not songName:
+            embed_title =f"Matching Songs for {key} {mode}"
+        else:
+            embed_title = f"Songs Matching {songName}"
+            matched_tracks = list(filter(lambda track: track["track"]["tt"] != songName, matched_tracks))
+
+        for i in range(0, len(matched_tracks), 25):
+            embed = discord.Embed(
+                title=embed_title,
+                description=f"Choose any of these Jam Tracks for a seamless mix!",
+                color=0x8927A1
+            )
+
+            tracks_chunk = matched_tracks[i:i + 25]
+
+            for track in tracks_chunk:
+                embed.add_field(name=(track["track"]["an"]).strip(), value=(track["track"]["tt"]).strip())
+
+            embed_array.append(embed)
+
+        if len(embed_array) == 1:
+            if should_edit_response:
+                await interaction.edit_original_response(embed=embed_array[0])
+            else:
+                await interaction.response.send_message(embed=embed_array[0])
+        else:
+            view = constants.PaginatorView(embed_array, interaction.user.id)
+            
+            if should_edit_response:
+                await interaction.edit_original_response(embed=view.get_embed(), view=view)
+            else:
+                await interaction.response.send_message(embed=view.get_embed(), view=view)
+
+    async def handle_keymode_match(self, interaction: discord.Interaction, key:constants.KeyTypes, mode:constants.ModeTypes):
+        # Convert our key and mode string into an Enum value
+        chosen_key = constants.KeyTypes[str(key).replace('KeyTypes.', '')].value
+        chosen_mode = constants.ModeTypes[str(mode).replace('ModeTypes.', '')].value
+
+        track_list = self.jam_track_handler.get_jam_tracks()
+
+        if not track_list:
+            await interaction.response.send_message(embed=constants.common_error_embed('Could not get tracks.'), ephemeral=True)
+            return
+        matched_tracks = self.jam_track_handler.get_matching_key_mode_jam_tracks(track_list, chosen_key.code, chosen_mode.code)
+
+        await self.handle_embed(interaction=interaction, matched_tracks=matched_tracks, key=chosen_key.code, mode=chosen_mode.code,should_edit_response=False)
+
+    async def handle_keymode_match_from_song(self, interaction: discord.Interaction, song:str):
+        view: ResultsJamTracks
+        track_list = self.jam_track_handler.get_jam_tracks()
+
+        if not track_list:
+            await interaction.response.send_message(embed=constants.common_error_embed('Could not get tracks.'), ephemeral=True)
+            return
+
+        matched_tracks = self.jam_track_handler.fuzzy_search_tracks(track_list, song)
+        if not matched_tracks:
+            await interaction.response.send_message(embed=constants.common_error_embed(f"The search query \"{song}\" did not give any results."))
+            return
+        
+        async def selected(new_interaction: discord.Interaction):
+            if new_interaction:
+                if new_interaction.user.id != interaction.user.id:
+                    await interaction.edit_original_response(content="", embed=constants.common_error_embed("This is not your session. Please start your own session."))
+                    return
+
+                await new_interaction.response.defer()
+
+            is_timed_out = len(view.select.values) < 1
+            if is_timed_out:
+                return None
+
+            shortname = view.select.values[0]
+            view.stop()
+            return discord.utils.find(lambda t: t['track']['sn'] == shortname, matched_tracks)
+        
+        async def timed_out():
+            await interaction.edit_original_response(content="", embed=constants.common_error_embed("You didn't respond in time. Search cancelled."), view=None)
+            view.stop()
+        
+        if len(matched_tracks) > 1:
+            view = ResultsJamTracks(matched_tracks, selected)
+            view.on_timeout = timed_out
+            await interaction.response.send_message(view=view)
+            await view.wait()
+
+            track = await selected(None)
+
+            success_text = f"Searching for songs that match the key and mode of {track["track"]["tt"]}..."
+            await interaction.edit_original_response(content="", 
+                                                     embed= discord.Embed(colour=0x3AB00B, title="Success", description=success_text), 
+                                                     view=None)
+        else:
+            track = matched_tracks[0]
+        
+        should_edit_response = len(matched_tracks) > 1
+
+        chosen_key = constants.KeyTypes[track["track"]["mk"]].value
+        chosen_mode = constants.ModeTypes[track["track"]["mm"]].value
+
+        matched_tracks = self.jam_track_handler.get_matching_key_mode_jam_tracks(track_list, chosen_key.code, chosen_mode.code)
+
+        await self.handle_embed(interaction=interaction, matched_tracks=matched_tracks, key=chosen_key.code, mode=chosen_mode.code, songName=track["track"]["tt"], should_edit_response=should_edit_response)

--- a/bot/tracks.py
+++ b/bot/tracks.py
@@ -148,7 +148,13 @@ class JamTrackHandler:
 
     def get_jam_tracks(self):
         return constants.get_jam_tracks()
-        
+
+    def get_matching_key_mode_jam_tracks(self, tracks:list, key:str, mode:str):
+        exact_matches = []
+
+        exact_matches.extend([track for track in tracks if track['track']['mk'] == key and track['track']['mm'] == mode])
+        return exact_matches
+
 class SearchCommandHandler:
     def __init__(self, bot: commands.Bot) -> None:
         self.jam_track_handler = JamTrackHandler()

--- a/festivalinfobot.py
+++ b/festivalinfobot.py
@@ -36,6 +36,7 @@ from bot.tools.subscriptionman import SubscriptionManager
 from bot.tracks import SearchCommandHandler, JamTrackHandler
 from bot.helpers import DailyCommandHandler, ShopCommandHandler, TracklistHandler, ProVocalsHandler
 from bot.graph import GraphCommandsHandler
+from bot.mix import MixHandler
 from bot.groups.oauthmanager import OAuthManager
 
 import traceback
@@ -196,6 +197,7 @@ class FestivalInfoBot(commands.AutoShardedBot):
         self.check_handler = LoopCheckHandler(self)
         self.oauth_manager = OAuthManager(self, constants.EPIC_DEVICE_ID, constants.EPIC_ACCOUNT_ID, constants.EPIC_DEVICE_SECRET)
         self.pro_vocals_handler = ProVocalsHandler(self)
+        self.mix_handler = MixHandler()
 
         self.setup_commands()
 
@@ -356,6 +358,17 @@ class FestivalInfoBot(commands.AutoShardedBot):
         @app_commands.describe(artist = "A search query to use in the song name.")
         async def tracklist_command(interaction: discord.Interaction, artist:str):
             await self.tracklist_handler.handle_artist_interaction(interaction=interaction, artist=artist)
+
+        @filter_group.command(name="mix", description="Browse the list of Jam Tracks that match a key and mode to create a seamless mix.")
+        @app_commands.describe(key = "The key of the Jam Track you're currently mixing with.")
+        @app_commands.describe(mode = "The mode of the Jam Track you're currently mixing with.")
+        async def tracklist_command(interaction: discord.Interaction, key:constants.KeyTypes, mode:constants.ModeTypes):
+            await self.mix_handler.handle_keymode_match(interaction=interaction, key=key, mode=mode)
+
+        @filter_group.command(name="mixwithsong", description="Browse the list of Jam Tracks that match a key/mode of a specific song to create a seamless mix.")
+        @app_commands.describe(song = "The Jam Track you'd like to mix with.")
+        async def tracklist_command(interaction: discord.Interaction, song:str):
+            await self.mix_handler.handle_keymode_match_from_song(interaction=interaction, song=song)
 
         self.tree.add_command(tracklist_group)
 


### PR DESCRIPTION
- Adds command "/mix" that takes in a key (A/B/C/Eb/etc.) and a mode (Major/Minor) and queries the list of jam tracks for songs that match that key/mode.
- Adds command "/mixwithsong" that takes in a search query and finds matching jam tracks. If there's more than one, the user can select a jam track from a dropdown. Then finds the best matching jam tracks for that song's key and mode.
- Supports multiple pages if more than 25 responses are found.
- Shuffles the results for some uniqueness each time (e.g., if we had three pages, you might not always want to be scrolling three pages- might be more worth it to see a song on page 1 you hadn't seen before)